### PR TITLE
Add C Memory Operations in JPMemory/Fix memory leaks 

### DIFF
--- a/Extensions/CoreGraphics/JPCGBitmapContext.m
+++ b/Extensions/CoreGraphics/JPCGBitmapContext.m
@@ -39,6 +39,10 @@
     context[@"CGBitmapContextGetWidth"]       = ^size_t(JSValue *c) {
         return CGBitmapContextGetWidth([self formatPointerJSToOC:c]);
     };
+    
+    context[@"CGImageRelease"]                = ^void(JSValue *image) {
+        CGImageRelease([self formatPointerJSToOC:image]);
+    };
 }
 
 @end

--- a/Extensions/CoreGraphics/JPCGColor.m
+++ b/Extensions/CoreGraphics/JPCGColor.m
@@ -19,6 +19,7 @@
             components[i] = [componentsArray[i] doubleValue];
         }
         CGColorRef color =  CGColorCreate([self formatPointerJSToOC:space], components);
+        free(components);
         return [self formatPointerOCToJS:color];
     };
     

--- a/Extensions/CoreGraphics/JPCGContext.m
+++ b/Extensions/CoreGraphics/JPCGContext.m
@@ -89,6 +89,7 @@
             pointsArray[i]   = point;
         }
         CGContextAddLines([self formatPointerJSToOC:c], pointsArray, count);
+        free(pointsArray);
     };
     
     context[@"CGContextAddEllipseInRect"]      = ^void(JSValue *c, NSDictionary *rectDict){
@@ -221,6 +222,7 @@
             lengthsArray[i] = [lengths[i] doubleValue];
         }
         CGContextSetLineDash([self formatPointerJSToOC:c], phase, lengthsArray, count);
+        free(lengthsArray);
     };
     
     context[@"CGContextRotateCTM"]               = ^void(JSValue *c, CGFloat angle) {

--- a/Extensions/CoreGraphics/JPCGImage.m
+++ b/Extensions/CoreGraphics/JPCGImage.m
@@ -26,6 +26,7 @@
                 decode[i] = [decodeArray[i] doubleValue];
             }
             CGImageRef  createdImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel,bytesPerRow, [self formatPointerJSToOC:space], bitmapInfo, [self formatPointerJSToOC:provider], decode, shouldInterpolate, intent);
+            free(decode);
             return [self formatPointerOCToJS:createdImage];
         }
     };

--- a/Extensions/CoreGraphics/JPCGPath.m
+++ b/Extensions/CoreGraphics/JPCGPath.m
@@ -63,6 +63,7 @@
         CGAffineTransform transform;
         [JPCGTransform transStruct:&transform ofDict:m];
         CGPathAddLines([self formatPointerJSToOC:path], &transform, points, count);
+        free(points);
     };
 
     context[@"CGPathAddRect"]                 = ^void(JSValue *path, NSDictionary *m,

--- a/Extensions/JPMemory.m
+++ b/Extensions/JPMemory.m
@@ -12,6 +12,20 @@
 
 - (void)main:(JSContext *)context
 {
+    context[@"memset"]  = ^void(JSValue *jsVal, int ch,size_t n) {
+        memset([self formatPointerJSToOC:jsVal], ch, n);
+    };
+    
+    context[@"memmove"] = ^id(JSValue *des, JSValue *src, size_t n) {
+        void *ret = memmove([self formatPointerJSToOC:des], [self formatPointerJSToOC:src], n);
+        return [self formatPointerOCToJS:ret];
+    };
+    
+    context[@"memcpy"]  = ^id(JSValue *des, JSValue *src, size_t n) {
+        void *ret = memcpy([self formatPointerJSToOC:des], [self formatPointerJSToOC:src], n);
+        return [self formatPointerOCToJS:ret];
+    };
+    
     context[@"malloc"] = ^id(size_t size) {
         void *m = malloc(size);
         return [self formatPointerOCToJS:m];
@@ -20,6 +34,23 @@
     context[@"free"]   = ^void(JSValue *jsVal) {
         void *m = [self formatPointerJSToOC:jsVal];
         free(m);
+    };
+    
+    context[@"pval"]    = ^id(JSValue *jsVal) {
+        void *m = [self formatPointerJSToOC:jsVal];
+        id obj = *((__unsafe_unretained id *)m);
+        return [self formatOCToJS:obj];
+    };
+    
+    context[@"getpointer"] = ^id(JSValue *jsVal) {
+        void *pointer = [self getPointerFromJS:jsVal];
+        return [self formatPointerOCToJS:pointer];
+    };
+    
+    context[@"pvalWithBool"] = ^id(JSValue *jsVal) {
+        void *m = [self formatPointerJSToOC:jsVal];
+        BOOL b = *((BOOL *)m);
+        return [self formatOCToJS:[NSNumber numberWithBool:b]];
     };
     
 }

--- a/Extensions/UIKit/JPUIGraphics.m
+++ b/Extensions/UIKit/JPUIGraphics.m
@@ -34,9 +34,6 @@
     
     context[@"UIGraphicsGetImageFromCurrentImageContext"] = ^id() {
         UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-        if (image == nil) {
-            NSLog(@"nil");
-        }
         return [self formatOCToJS:image];
     };
     

--- a/JSPatch/JPEngine.h
+++ b/JSPatch/JPEngine.h
@@ -33,5 +33,6 @@
 - (id)formatPointerOCToJS:(void *)pointer;
 - (id)formatJSToOC:(JSValue *)val;
 - (id)formatOCToJS:(id)obj;
+- (void *)getPointerFromJS:(JSValue *)val;
 @end
 

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -88,6 +88,29 @@ id formatOCToJS(id obj);
     return formatOCToJS(obj);
 }
 
+- (void *)getPointerFromJS:(JSValue *)val
+{
+    void **p = malloc(sizeof(void *));
+    if ([[val toObject] isKindOfClass:[NSDictionary class]]) {
+        if ([[val toObject][@"__obj"] isKindOfClass:[JPBoxing class]]) {
+            void *pointer = [(JPBoxing *)[val toObject][@"__obj"] unboxPointer];
+            if (pointer != NULL) {
+                *p = pointer;
+            }else {
+                id jpobj = [(JPBoxing *)[val toObject][@"__obj"] unbox];
+                *p = (__bridge void *)jpobj;
+            }
+        }else {
+            id obj = [val toObject][@"__obj"];
+            *p     = (__bridge void *)obj;
+        }
+        return p;
+    }else {
+        NSAssert(NO, @"getpointer only support pointer and id type!");
+        return NULL;
+    }
+}
+
 @end
 
 

--- a/JSPatchDemo/JSPatchTests/JPTestObject.h
+++ b/JSPatchDemo/JSPatchTests/JPTestObject.h
@@ -69,6 +69,7 @@
 @property (nonatomic, assign) BOOL funcToSwizzleTestPointerPassed;
 @property (nonatomic, assign) BOOL funcTestPointerPassed;
 @property (nonatomic, assign) BOOL funcTestSizeofPassed;
+@property (nonatomic, assign) BOOL funcTestGetPointerPassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzlePassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnObjPassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnObjCalledOriginalPassed;

--- a/JSPatchDemo/JSPatchTests/JPTestObject.m
+++ b/JSPatchDemo/JSPatchTests/JPTestObject.m
@@ -363,6 +363,32 @@ typedef struct {
     self.funcTestPointerPassed = testStruct->idx == 42 && strcmp(testStruct->name, "JSPatch") == 0;
 }
 
+- (BOOL)funcTestGetPointer1:(NSString *)str
+{
+    if ([str isEqualToString:@"JSPatch"]) {
+        return YES;
+    }
+    return NO;
+}
+
+- (BOOL)funcTestGetPointer2:(NSError *)error
+{
+    if ([[[error userInfo] description] isEqualToString:[@{@"msg":@"test"} description]]) {
+        return YES;
+    }
+    return NO;
+}
+
+- (BOOL)funcTestGetPointer3:(void *)arr
+{
+    char *p = arr;
+    for (int i = 0; i < 10; i++) {
+        if (p[i] != 'A') {
+            return false;
+        }
+    }
+    return true;
+}
 
 + (void)classFuncToSwizzle:(JPTestObject *)testObject int:(NSInteger)i
 {

--- a/JSPatchDemo/JSPatchTests/JSPatchTests.m
+++ b/JSPatchDemo/JSPatchTests/JSPatchTests.m
@@ -15,7 +15,7 @@
 #import "JPInclude.h"
 #import "JPCoreGraphics.h"
 #import "JPUIKit.h"
-
+#import "JPMemory.h"
 @interface JSPatchTests : XCTestCase
 
 @end
@@ -31,7 +31,7 @@
 - (void)setUp {
     [super setUp];
     [JPEngine startEngine];
-    [JPEngine addExtensions:@[[JPInclude instance], [JPCoreGraphics instance],[JPUIKit instance]]];
+    [JPEngine addExtensions:@[[JPInclude instance], [JPCoreGraphics instance],[JPUIKit instance],[JPMemory instance]]];
 }
 
 - (void)tearDown {
@@ -106,7 +106,7 @@
     XCTAssert(obj.funcToSwizzleTestPointerPassed, @"funcToSwizzleTestPointerPassed");
     XCTAssert(obj.funcTestPointerPassed, @"funcTestPointerPassed");
     XCTAssert(obj.funcTestSizeofPassed,@"funcSizeofPassed");
-
+    XCTAssert(obj.funcTestGetPointerPassed, @"funcGetPointerPassed");
     NSDictionary *originalDict = @{@"k": @"v"};
     NSDictionary *dict = [obj funcToSwizzleReturnDictionary:originalDict];
     XCTAssert(originalDict == dict, @"funcToSwizzleReturnDictionary");

--- a/JSPatchDemo/JSPatchTests/test.js
+++ b/JSPatchDemo/JSPatchTests/test.js
@@ -312,4 +312,47 @@ var global = this;
   var edgeInsetsSize = sizeof("UIEdgeInsets")
   var transformSize  = sizeof("CGAffineTransform")
   obj.setFuncTestSizeofPassed(rectSize > 0 && pointSize > 0 && sizeSize > 0 && vectorSize > 0 && edgeInsetsSize > 0 && transformSize > 0)
+ 
+//getPointerTest1 - Test Object in JPBoxing
+  var sig = require('JPTestObject').instanceMethodSignatureForSelector("funcTestGetPointer1:");
+  var invocation = require('NSInvocation').invocationWithMethodSignature(sig)
+  var str = require('NSString').stringWithString('JSPatch')
+  invocation.setTarget(obj)
+  invocation.setSelector("funcTestGetPointer1:")
+  invocation.setArgument_atIndex(getpointer(str), 2)
+  invocation.invoke()
+  var ret1 = malloc(1)
+  invocation.getReturnValue(ret1)
+  var bool1 =  pvalWithBool(ret1)
+ 
+//getPointerTest2 -  Test Normal Object
+  var sig = require('JPTestObject').instanceMethodSignatureForSelector("funcTestGetPointer2:");
+  var invocation = require('NSInvocation').invocationWithMethodSignature(sig)
+  var err = require('NSError').errorWithDomain_code_userInfo("com.albert43",45,{msg:"test"});
+  invocation.setTarget(obj)
+  invocation.setSelector("funcTestGetPointer2:")
+  invocation.setArgument_atIndex(getpointer(err), 2)
+  invocation.invoke()
+  var ret2 = malloc(1)
+  invocation.getReturnValue(ret2);
+  var bool2 =  pvalWithBool(ret2)
+
+//getPointerTest3 -  Test Pointer
+  var ptr = malloc(10)
+  memset(ptr, 65, 10)
+  var sig = require('JPTestObject').instanceMethodSignatureForSelector("funcTestGetPointer3:");
+  var invocation = require('NSInvocation').invocationWithMethodSignature(sig)
+  invocation.setTarget(obj)
+  invocation.setSelector("funcTestGetPointer3:")
+  invocation.setArgument_atIndex(getpointer(ptr), 2)
+  invocation.invoke()
+  var ret3 = malloc(1)
+  invocation.getReturnValue(ret3);
+  var bool3 =  pvalWithBool(ret3)
+  obj.setFuncTestGetPointerPassed(bool1 && bool2 && bool3)
+  free(ret1)
+  free(ret2)
+  free(ret3)
+  free(ptr)
+ 
 })();


### PR DESCRIPTION
1. Now you use getpointer() in JPMemory Extensions to represent & operator to get the
pointer of an Objective-C object or a pointer. See the example in
`test.js` in demo

2. use pval() in JPMemory Extensions to access the Objective-C Object pointing by a pointer. Or
add a pvalWithXXX extension to access a c type pointer’s pointing
value.

3. add `memset`, `memmove`, `memcpy` in JPMemory

4. fix some memory leaks in Extensions in Extensions.