### PR TITLE
Bug fix: Support nil and [NSNull null] parameters in Block

### DIFF
--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -187,6 +187,10 @@ static NSMutableArray *_structExtensions;
         return formatJSToOC(obj);
     };
     
+    context[@"_OC_formatOCToJS"] = ^id(JSValue *obj) {
+        return formatOCToJS([obj toObject]);
+    };
+    
     _nullObj = [[NSObject alloc] init];
     _nilObj = [[NSObject alloc] init];
     context[@"_OC_null"] = formatOCToJS(_nullObj);

--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -37,7 +37,7 @@ var global = this
                 formatedArgs.splice(i, 1, null)
             }
         }
-        return obj.apply(obj, formatedArgs)
+        return _OC_formatOCToJS(obj.apply(obj, formatedArgs))
       }
     }
     if (obj instanceof Object) {

--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -27,9 +27,17 @@ var global = this
       return ret
     }
     if (obj instanceof Function) {
-      return function() {
-        var args = Array.prototype.slice.call(arguments)
-        return obj.apply(obj, _OC_formatJSToOC(args))
+        return function() {
+            var args = Array.prototype.slice.call(arguments)
+            var formatedArgs = _OC_formatJSToOC(args)
+            for (var i = 0; i < args.length; i++) {
+                if (args[i] === null || args[i] === undefined || args[i] === false) {
+                formatedArgs.splice(i, 1, undefined)
+            } else if (args[i] == nsnull) {
+                formatedArgs.splice(i, 1, null)
+            }
+        }
+        return obj.apply(obj, formatedArgs)
       }
     }
     if (obj instanceof Object) {
@@ -145,10 +153,7 @@ var global = this
   
   global.YES = 1
   global.NO = 0
+  global.nsnull = _OC_null
   global._formatOCToJS = _formatOCToJS
-  
-  global.__defineGetter__("nsnull", function() {
-    return _formatOCToJS(_OC_null)
-  });
   
 })()

--- a/JSPatchDemo/JSPatchTests/JPTestObject.h
+++ b/JSPatchDemo/JSPatchTests/JPTestObject.h
@@ -71,6 +71,7 @@
 @property (nonatomic, assign) BOOL funcTestSizeofPassed;
 @property (nonatomic, assign) BOOL funcTestGetPointerPassed;
 @property (nonatomic, assign) BOOL funcTestNSErrorPointerPassed;
+@property (nonatomic, assign) BOOL funcTestNilParametersInBlockPassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzlePassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnObjPassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnObjCalledOriginalPassed;

--- a/JSPatchDemo/JSPatchTests/JPTestObject.m
+++ b/JSPatchDemo/JSPatchTests/JPTestObject.m
@@ -396,6 +396,25 @@ typedef struct {
     return true;
 }
 
+typedef NSString * (^JSBlock)(NSError *);
+- (JSBlock)funcGenerateBlock {
+    JSBlock block = ^(NSError *err) {
+        if (err) {
+            return [err description];
+        }else {
+            return @"no error";
+        }
+    };
+    return block;
+}
+
+- (NSString *)excuteBlockWithNilParameters:(JSBlock)blk {
+    if (blk) {
+        return blk(nil);
+    }
+    return nil;
+}
+
 + (void)classFuncToSwizzle:(JPTestObject *)testObject int:(NSInteger)i
 {
     

--- a/JSPatchDemo/JSPatchTests/JSPatchTests.m
+++ b/JSPatchDemo/JSPatchTests/JSPatchTests.m
@@ -108,6 +108,7 @@
     XCTAssert(obj.funcTestSizeofPassed,@"funcSizeofPassed");
     XCTAssert(obj.funcTestGetPointerPassed, @"funcGetPointerPassed");
     XCTAssert(obj.funcTestNSErrorPointerPassed, @"funcTestNSErrorPointerPassed");
+    XCTAssert(obj.funcTestNilParametersInBlockPassed, @"funcTestNilParametersInBlockPassed");
     NSDictionary *originalDict = @{@"k": @"v"};
     NSDictionary *dict = [obj funcToSwizzleReturnDictionary:originalDict];
     XCTAssert(originalDict == dict, @"funcToSwizzleReturnDictionary");

--- a/JSPatchDemo/JSPatchTests/test.js
+++ b/JSPatchDemo/JSPatchTests/test.js
@@ -368,4 +368,13 @@ var global = this;
   releaseTmpObj(p_error)
   free(p_error)
 
+//funcTestNilParametersInBlock
+  var blk  = obj.funcGenerateBlock()
+  var str1 = blk(obj.funcReturnNil())
+  var str2 = blk(null)
+  var str3 = obj.excuteBlockWithNilParameters(block("NSError *", blk))
+  if (str1 == "no error" && str2 == "no error" && str3.toJS() == "no error") {
+    obj.setFuncTestNilParametersInBlockPassed(true)
+  }
+
 })();

--- a/JSPatchDemo/JSPatchTests/test.js
+++ b/JSPatchDemo/JSPatchTests/test.js
@@ -214,7 +214,7 @@ var global = this;
     str: "stringFromJS",
     view: view
   }, view)
-  obj.setFuncReturnObjectBlockReturnValuePassed(blkRet == "succ")
+  obj.setFuncReturnObjectBlockReturnValuePassed(blkRet.toJS() == "succ")
 
   obj.callBlockWithStringAndInt(block("NSString *, int", function(str, num) {
     obj.setCallBlockWithStringAndIntPassed(str.toJS() == "stringFromOC" && num == 42)
@@ -237,7 +237,7 @@ var global = this;
       "str": "stringFromJS",
       "view": view
     }: {}), view)
-    obj.setCallBlockWithObjectAndBlockReturnValuePassed(ret == "succ")
+    obj.setCallBlockWithObjectAndBlockReturnValuePassed(ret.toJS() == "succ")
   }))
 
   //////super
@@ -373,7 +373,8 @@ var global = this;
   var str1 = blk(obj.funcReturnNil())
   var str2 = blk(null)
   var str3 = obj.excuteBlockWithNilParameters(block("NSError *", blk))
-  if (str1 == "no error" && str2 == "no error" && str3.toJS() == "no error") {
+  console.log(str1.toJS())
+  if (str1.toJS() == "no error" && str2.toJS() == "no error" && str3.toJS() == "no error") {
     obj.setFuncTestNilParametersInBlockPassed(true)
   }
 


### PR DESCRIPTION
Support to call block with `nil` or `[NSNull null]` parameters in Javascript now. See the `funcTestNilParametersInBlock` example in `test.js`