### PR TITLE
Add performSelector() in JS

### DIFF
--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -50,17 +50,19 @@ var global = this
     return obj
   }
   
-  var _methodFunc = function(instance, clsName, methodName, args, isSuper) {
-    methodName = methodName.replace(/__/g, "-")
-    var selectorName = methodName.replace(/_/g, ":").replace(/-/g, "_")
-    var marchArr = selectorName.match(/:/g)
-    var numOfArgs = marchArr ? marchArr.length : 0
-    if (args.length > numOfArgs) {
-      selectorName += ":"
+  var _methodFunc = function(instance, clsName, methodName, args, isSuper, isPerformSelector) {
+    var selectorName = methodName
+    if (!isPerformSelector) {
+      methodName = methodName.replace(/__/g, "-")
+      selectorName = methodName.replace(/_/g, ":").replace(/-/g, "_")
+      var marchArr = selectorName.match(/:/g)
+      var numOfArgs = marchArr ? marchArr.length : 0
+      if (args.length > numOfArgs) {
+        selectorName += ":"
+      }
     }
     var ret = instance ? _OC_callI(instance, selectorName, args, isSuper):
                          _OC_callC(clsName, selectorName, args)
-
     return _formatOCToJS(ret)
   }
 
@@ -79,6 +81,13 @@ var global = this
     if (methodName == 'super') {
       return function() {
         return {__obj: self.__obj, __clsName: self.__clsName, __isSuper: 1}
+      }
+    }
+
+    if (methodName == 'performSelector') {
+      return function(){
+        var args = Array.prototype.slice.call(arguments)
+        return _methodFunc(self.__obj, self.__clsName, args[0], args.splice(1), self.__isSuper, true)
       }
     }
     return function(){


### PR DESCRIPTION
Now you can use performSelector() to call a Objective-C method with selectorname in JSPatch and unnecessary to worry about the underline problem.  In performSelector(), the first parameter is the selectorName, and following are the parameters of Objective-C method. 
Example:
---
An Objective-C method:
```objc
- (void)__privateMethodWithPramOne:(NSString *)pram1 pramTwo:(NSString *)pram2  {
    NSLog("I'm a privateMethod with %@ and %@", pram1, pram2).
}
```

call the Objective-C method with performSelector() in JSPatch
```javascript
self.performSelector("__privateMethodWithPramOne:pramTwo:","pram1", "pram2")
```