### PR TITLE
Add Cache for MethodSignature

### DIFF
--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -61,7 +61,7 @@ var global = this
         selectorName += ":"
       }
     }
-    var ret = instance ? _OC_callI(instance, selectorName, args, isSuper):
+    var ret = instance ? _OC_callI(clsName, instance, selectorName, args, isSuper):
                          _OC_callC(clsName, selectorName, args)
     return _formatOCToJS(ret)
   }


### PR DESCRIPTION
Caching the MethodSignature when  calling  Objective-C methods in Javascript. Make the performance 25% faster than before.