### PR TITLE
Add __bridge_id and CFRelease to JPMemory

### DIFF
--- a/Extensions/JPMemory.m
+++ b/Extensions/JPMemory.m
@@ -78,6 +78,16 @@
         }
         return 0;
     };
+    
+    context[@"__bridge_id"] = ^id(JSValue *jsVal) {
+        void *p = [self formatPointerJSToOC:jsVal];
+        id obj = (__bridge id)p;
+        return [self formatOCToJS:obj];
+    };
+    
+    context[@"CFRelease"] = ^void(JSValue *jsVal) {
+        CFRelease([self formatPointerJSToOC:jsVal]);
+    };
 }
 
 


### PR DESCRIPTION
1、use __bridge_id to bridge CF Object to an id object like:
```objc
//Objective-C
self.view.layer.contents = (__bridge id)[UIImage imageNamed:@"pic.jpeg"].CGImage
```
```javascript
//Javascript
var cgImage = __bridge_id(require('UIImage').imageNamed('pic.jpeg').CGImage())
self.view().layer().setContents(cgImage)
```
2、add CFRelease.