### PR TITLE
native调用被js重写的方法时，将第一个参数slf封装为JPBoxing对象，解决调用完js重写方法后不能及时释放self的问题

### DIFF
--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -434,7 +434,7 @@ static void JPForwardInvocation(id slf, SEL selector, NSInvocation *invocation)
     if ([slf class] == slf) {
         [argList addObject:[JSValue valueWithObject:@{@"__clsName": NSStringFromClass([slf class])} inContext:_context]];
     } else {
-        [argList addObject:slf];
+        [argList addObject:[JPBoxing boxWeakObj:slf]];
     }
     
     for (NSUInteger i = 2; i < numberOfArguments; i++) {

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -103,8 +103,43 @@ static NSMutableDictionary *registeredStruct;
 
     __weak JSContext *weakCtx = context;
     context[@"dispatch_after"] = ^(double time, JSValue *func) {
+        id tmpSelf = formatJSToOC(weakCtx[@"self"]);
+        
         JSValue *currSelf = weakCtx[@"self"];
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(time * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            NSLog(@"JSPatch GCD: the current self is %@", tmpSelf);
+            JSValue *prevSelf = weakCtx[@"self"];
+            
+            weakCtx[@"self"] = currSelf;
+            [func callWithArguments:nil];
+            weakCtx[@"self"] = prevSelf;
+            
+        });
+    };
+    
+    context[@"dispatch_after_weak_self"] = ^(double time, JSValue *func) {
+        __weak id tmpSelf = formatJSToOC(weakCtx[@"self"]);
+        
+        JSValue *currSelf = weakCtx[@"self"];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(time * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            
+            NSLog(@"JSPatch GCD: the current self is %@", tmpSelf);
+            JSValue *prevSelf = weakCtx[@"self"];
+            
+            weakCtx[@"self"] = currSelf;
+            [func callWithArguments:nil];
+            weakCtx[@"self"] = prevSelf;
+            
+        });
+    };
+    
+    context[@"dispatch_async_main"] = ^(JSValue *func) {
+        id tmpSelf = formatJSToOC(weakCtx[@"self"]);
+        
+        JSValue *currSelf = weakCtx[@"self"];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            
+            NSLog(@"JSPatch GCD: the current self is %@", tmpSelf);
             JSValue *prevSelf = weakCtx[@"self"];
             weakCtx[@"self"] = currSelf;
             [func callWithArguments:nil];
@@ -112,9 +147,13 @@ static NSMutableDictionary *registeredStruct;
         });
     };
     
-    context[@"dispatch_async_main"] = ^(JSValue *func) {
+    context[@"dispatch_async_main_weak_self"] = ^(JSValue *func) {
+        __weak id tmpSelf = formatJSToOC(weakCtx[@"self"]);
+        
         JSValue *currSelf = weakCtx[@"self"];
         dispatch_async(dispatch_get_main_queue(), ^{
+            
+            NSLog(@"JSPatch GCD: the current self is %@", tmpSelf);
             JSValue *prevSelf = weakCtx[@"self"];
             weakCtx[@"self"] = currSelf;
             [func callWithArguments:nil];
@@ -133,8 +172,24 @@ static NSMutableDictionary *registeredStruct;
     };
     
     context[@"dispatch_async_global_queue"] = ^(JSValue *func) {
+        id tmpSelf = formatJSToOC(weakCtx[@"self"]);
+        
         JSValue *currSelf = weakCtx[@"self"];
         dispatch_async(dispatch_get_global_queue(0, 0), ^{
+            NSLog(@"JSPatch GCD: the current self is %@", tmpSelf);
+            JSValue *prevSelf = weakCtx[@"self"];
+            weakCtx[@"self"] = currSelf;
+            [func callWithArguments:nil];
+            weakCtx[@"self"] = prevSelf;
+        });
+    };
+    
+    context[@"dispatch_async_global_queue_weak_self"] = ^(JSValue *func) {
+        __weak id tmpSelf = formatJSToOC(weakCtx[@"self"]);
+        
+        JSValue *currSelf = weakCtx[@"self"];
+        dispatch_async(dispatch_get_global_queue(0, 0), ^{
+            NSLog(@"JSPatch GCD: the current self is %@", tmpSelf);
             JSValue *prevSelf = weakCtx[@"self"];
             weakCtx[@"self"] = currSelf;
             [func callWithArguments:nil];
@@ -1227,7 +1282,24 @@ static id formatJSToOC(JSValue *jsval)
     id obj = [jsval toObject];
     if (!obj || [obj isKindOfClass:[NSNull class]]) return _nilObj;
     
-    if ([obj isKindOfClass:[JPBoxing class]]) return [obj unbox];
+    if ([obj isKindOfClass:[JPBoxing class]]) {
+        JPBoxing *boxing = obj;
+        
+        while ([boxing isKindOfClass:[JPBoxing class]]) {
+            if (!boxing.obj && !boxing.weakObj) {
+                boxing = nil;
+            } else {
+                boxing = [boxing unbox];
+            }
+        }
+        if (!boxing || [boxing isKindOfClass:[NSNull class]]) {
+            return _nilObj;
+        } else {
+            return boxing;
+        }
+        
+    }
+    
     if ([obj isKindOfClass:[NSArray class]]) {
         NSMutableArray *newArr = [[NSMutableArray alloc] init];
         for (int i = 0; i < [obj count]; i ++) {


### PR DESCRIPTION
Hi,
      工作中用到了JSPatch。然而调用完js重写的方法时，对象不能及时释放，致使对象dealloc中的方法没能及时调用，引起些问题。
      个人觉得，调用JS重写的方法时，传递的第一个参数slf不必要使用强引用，所以建议使用[JPBoxing boxWeakObj:slf]（JSPatch/JPEngine.m line 437）代替slf。这样就不会影响OC的内存管理逻辑。
     但毕竟对JSPatch的理解没那么深入，有些问题可能没考虑到，承望不吝赐教。