### PR TITLE
支持新增protocol 实现新增非id的方法

### DIFF
--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -359,29 +359,36 @@ static void addGroupMethodsToProtocol(Protocol* protocol,JSValue *groupMethods,B
         {
             //type encode string create
             NSMutableDictionary* typeEncodeDic = [[NSMutableDictionary alloc]init];
-            #define JP_DEFINE_TYPE_ENCODE_CASE(_typeString, _type) \
-            if ([_typeString length] > 0) {\
+            #define JP_DEFINE_TYPE_ENCODE_CASE(_type) \
+            if ([@#_type length] > 0) {\
                 char* encode = @encode(_type);\
                 NSString * encodestr = [NSString stringWithUTF8String:encode];\
-                [typeEncodeDic setObject:encodestr forKey:_typeString];\
+                [typeEncodeDic setObject:encodestr forKey:@#_type];\
             }
-            JP_DEFINE_TYPE_ENCODE_CASE(@"id", id);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"BOOL", BOOL);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"int", int);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"void", void);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"char", char);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"short", short);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"unsigned short", unsigned short);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"unsigned int", unsigned int);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"long", long);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"unsigned long", unsigned long);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"long long", long long);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"float", float);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"double", double);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"CGFloat", CGFloat);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"CGSize", CGSize);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"CGRect", CGRect);
-            JP_DEFINE_TYPE_ENCODE_CASE(@"NSInteger", NSInteger);
+            JP_DEFINE_TYPE_ENCODE_CASE(id);
+            JP_DEFINE_TYPE_ENCODE_CASE(BOOL);
+            JP_DEFINE_TYPE_ENCODE_CASE(int);
+            JP_DEFINE_TYPE_ENCODE_CASE(void);
+            JP_DEFINE_TYPE_ENCODE_CASE(char);
+            JP_DEFINE_TYPE_ENCODE_CASE(short);
+            JP_DEFINE_TYPE_ENCODE_CASE(unsigned short);
+            JP_DEFINE_TYPE_ENCODE_CASE(unsigned int);
+            JP_DEFINE_TYPE_ENCODE_CASE(long);
+            JP_DEFINE_TYPE_ENCODE_CASE(unsigned long);
+            JP_DEFINE_TYPE_ENCODE_CASE(long long);
+            JP_DEFINE_TYPE_ENCODE_CASE(float);
+            JP_DEFINE_TYPE_ENCODE_CASE(double);
+            JP_DEFINE_TYPE_ENCODE_CASE(CGFloat);
+            JP_DEFINE_TYPE_ENCODE_CASE(CGSize);
+            JP_DEFINE_TYPE_ENCODE_CASE(CGRect);
+            JP_DEFINE_TYPE_ENCODE_CASE(CGPoint);
+            JP_DEFINE_TYPE_ENCODE_CASE(CGVector);
+            JP_DEFINE_TYPE_ENCODE_CASE(UIEdgeInsets);
+            JP_DEFINE_TYPE_ENCODE_CASE(NSInteger);
+            JP_DEFINE_TYPE_ENCODE_CASE(Class);
+            JP_DEFINE_TYPE_ENCODE_CASE(SEL);
+            
+            [typeEncodeDic setObject:@"@?" forKey:@"block"];
             
             
             NSString* returnEncode = [typeEncodeDic objectForKey:returnString];
@@ -391,7 +398,15 @@ static void addGroupMethodsToProtocol(Protocol* protocol,JSValue *groupMethods,B
                 for (NSInteger i = 0; i < ArgStrArr.count; i++) {
                     NSString* argstr = [ArgStrArr objectAtIndex:i];
                     NSString* argencode = [typeEncodeDic objectForKey:argstr];
-                    [encode appendString:argencode];
+                    if (argencode.length <= 0) {
+                        Class cls = NSClassFromString(argstr);
+                        if ([(id)cls isKindOfClass:[NSObject class]]) {
+                            argencode = @"@";
+                        }
+                    }
+                    if (argencode.length > 0) {
+                        [encode appendString:argencode];
+                    }
                 }
                 addMethodToProtocol(protocol, selectorName, encode, isInstance);
             }

--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -147,6 +147,13 @@ var global = this
     return require(ret["cls"])
   }
 
+  global.defineProtocol = function(declaration, protoMethods) {
+  
+      var ret = _OC_defineProtocol(declaration, protoMethods)
+      
+      return ret
+  }
+
   global.block = function(args, cb) {
     var slf = this
     if (args instanceof Function) {

--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -147,10 +147,29 @@ var global = this
     return require(ret["cls"])
   }
 
-  global.defineProtocol = function(declaration, protoMethods) {
-  
-      var ret = _OC_defineProtocol(declaration, protoMethods)
-      
+  var _formatDefineProtocols = function(protos, newProtos) {
+      var num = protos.length;
+      for (var i=0; i < num; i++) {
+          var protoInfo = protos[i];
+          var newProtoInfo = {};
+          for (var key in protoInfo) {
+              if (key != "defineTypeEncoding"){
+                  var method = protoInfo[key];
+                  newProtoInfo[key] = method.length;
+              }else
+              {
+                  newProtoInfo[key] = protoInfo[key];
+              }
+          }
+          newProtos.push(newProtoInfo);
+      }
+  }
+  global.defineProtocol = function(declaration, instProtos , clsProtos) {
+      var newInstProtos = [], newClsProtos = [];
+      clsProtos = clsProtos||[];
+      _formatDefineProtocols(instProtos, newInstProtos);
+      _formatDefineProtocols(clsProtos, newClsProtos);
+      var ret = _OC_defineProtocol(declaration, newInstProtos,newClsProtos);
       return ret
   }
 

--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -147,29 +147,8 @@ var global = this
     return require(ret["cls"])
   }
 
-  var _formatDefineProtocols = function(protos, newProtos) {
-      var num = protos.length;
-      for (var i=0; i < num; i++) {
-          var protoInfo = protos[i];
-          var newProtoInfo = {};
-          for (var key in protoInfo) {
-              if (key != "defineTypeEncoding"){
-                  var method = protoInfo[key];
-                  newProtoInfo[key] = method.length;
-              }else
-              {
-                  newProtoInfo[key] = protoInfo[key];
-              }
-          }
-          newProtos.push(newProtoInfo);
-      }
-  }
   global.defineProtocol = function(declaration, instProtos , clsProtos) {
-      var newInstProtos = [], newClsProtos = [];
-      clsProtos = clsProtos||[];
-      _formatDefineProtocols(instProtos, newInstProtos);
-      _formatDefineProtocols(clsProtos, newClsProtos);
-      var ret = _OC_defineProtocol(declaration, newInstProtos,newClsProtos);
+      var ret = _OC_defineProtocol(declaration, instProtos,clsProtos);
       return ret
   }
 

--- a/JSPatchDemo/JSPatchDemo.xcodeproj/project.pbxproj
+++ b/JSPatchDemo/JSPatchDemo.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		36F0DC791BF6D5D20090EA4A /* JPLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 36F0DC781BF6D5D20090EA4A /* JPLoader.m */; };
 		36F0DCC61BFAF41C0090EA4A /* libz.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 36F0DCC51BFAF41C0090EA4A /* libz.1.dylib */; };
 		3F6C38EB1B4A37D600F88662 /* JPMemory.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C38EA1B4A37D600F88662 /* JPMemory.m */; };
+		6C9C0EDF1C25122E00FCAAC5 /* newProtocolTest.js in Resources */ = {isa = PBXBuildFile; fileRef = 6C9C0EDE1C25122E00FCAAC5 /* newProtocolTest.js */; };
 		DE58B6481B7C312800F64C63 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE58B6471B7C312800F64C63 /* JavaScriptCore.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		DE6FFEED1B4243500005EE83 /* JPInclude.m in Sources */ = {isa = PBXBuildFile; fileRef = DE6FFEEB1B4243500005EE83 /* JPInclude.m */; };
 		DE6FFF031B42B01C0005EE83 /* protocolTest.js in Resources */ = {isa = PBXBuildFile; fileRef = DE6FFF021B42B01C0005EE83 /* protocolTest.js */; };
@@ -90,6 +91,7 @@
 		36F0DCC51BFAF41C0090EA4A /* libz.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.dylib; path = ../../../../../../usr/lib/libz.1.dylib; sourceTree = "<group>"; };
 		3F6C38E91B4A37D600F88662 /* JPMemory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JPMemory.h; sourceTree = "<group>"; };
 		3F6C38EA1B4A37D600F88662 /* JPMemory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JPMemory.m; sourceTree = "<group>"; };
+		6C9C0EDE1C25122E00FCAAC5 /* newProtocolTest.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = newProtocolTest.js; sourceTree = "<group>"; };
 		DE58B6471B7C312800F64C63 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		DE6FFEEA1B4243500005EE83 /* JPInclude.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JPInclude.h; sourceTree = "<group>"; };
 		DE6FFEEB1B4243500005EE83 /* JPInclude.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JPInclude.m; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 		DE94AE271AF246C000E461D4 /* JSPatchTests */ = {
 			isa = PBXGroup;
 			children = (
+				6C9C0EDE1C25122E00FCAAC5 /* newProtocolTest.js */,
 				E1B89E9E1B203482000645C2 /* JPMultithreadTestObject.h */,
 				E1B89E9F1B203482000645C2 /* JPMultithreadTestObject.m */,
 				DE94AE431AF2480000E461D4 /* JPTestObject.h */,
@@ -425,6 +428,7 @@
 				DE6FFF031B42B01C0005EE83 /* protocolTest.js in Resources */,
 				2D0DF7071B22F75C005695DA /* inheritTest.js in Resources */,
 				DE94AE471AF2480000E461D4 /* test.js in Resources */,
+				6C9C0EDF1C25122E00FCAAC5 /* newProtocolTest.js in Resources */,
 				E1B89EAE1B228818000645C2 /* multithreadTest.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JSPatchDemo/JSPatchTests/newProtocolTest.js
+++ b/JSPatchDemo/JSPatchTests/newProtocolTest.js
@@ -1,0 +1,60 @@
+
+defineProtocol('lalalala',{
+       testProtocol:{
+           paramsType:"BOOL",
+           returnType:"int",
+       },
+       testProtocol_withB:{
+           paramsType:"id,CGSize",
+           returnType:"NSInteger",
+       },
+       //you can use your classname or id  both is OK
+       testProtocol_withB_withC:{
+           paramsType:"CGRect,float,NSArray",
+           returnType:"id",
+       },
+       //block SEL ok
+       testProtocol_withBlock_withSEL:{
+           paramsType:"CGFloat,block,SEL",
+           returnType:"void",
+       },
+       //some unsupport type  you can use typeEncode
+       //make sure paramsType's number is right
+       testProtocolConstumStruct:{
+           paramsType:"unknown",
+           returnType:"int",
+           typeEncode:"i32@0:8{CGVector=dd}16",//or "i@:{CGVector=dd}"
+       },
+},{
+       xxxxx:{
+               paramsType:"BOOL",
+               returnType:"void",
+       },
+});
+
+//with new protocol  you can add no-id args method
+defineClass('lalalalaViewcontroller:UIViewController <lalalala>', {
+            testProtocolConstumStruct:function(oye){
+                return 6;
+            },
+                testProtocol: function(oye) {
+                return 1;
+            },
+            testProtocol_withB:function(str,size){
+                return 3;
+            },
+            testProtocol_withB_withC:function(rect,f,arr){
+                return "4";
+            },
+            testProtocol_withBlock_withSEL:function(f,b,s){
+                console.log("5")
+            },
+},{
+            xxxxx: function(oye) {
+                console.log("7")
+            },
+            
+});
+
+
+


### PR DESCRIPTION
defineProtocol can add new protocol
new protocol can help defineClass to add method with no-id args

more  testcase at newProtocolTest.js
```
defineProtocol('lalalala',{
       testProtocol:{
               paramsType:"BOOL",
               returnType:"int",
//               typeEncode:"i@:B",//Option
       },
       testProtocol_withB:{
       paramsType:"id,CGSize",
       returnType:"NSInteger",
       //               typeEncode:"i@:B",//Option
       }
},{
       xxxxx:{
               paramsType:"BOOL",
               returnType:"int",
//               typeEncode:"i@:B",//Option
       },
});

```

with this protocol
you can add this no-id args method

```
-(int)testProtocol:(BOOL)oye;

-(NSInteger)testProtocol:(NSString*)str withB:(CGSize)size;

+(int)xxxxx:(BOOL)oye;
```

```
defineClass('hahahaha:UIViewController <lalalala>', {
            testProtocol: function(oye) {
            return 1;
            },
            testProtocol_withB:function(str,size){
            return 3;
            }
},{
            xxxxx: function(oye) {
            return 2;
            },
            
});
```