### PR TITLE
Bug fix:block type return value convert

### DIFF
--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -1385,6 +1385,9 @@ static id formatJSToOC(JSValue *jsval)
             if ([ocObj isKindOfClass:[JPBoxing class]]) return [ocObj unbox];
             return ocObj;
         }
+        if (obj[@"__isBlock"]) {
+            return genCallbackBlock(jsval);
+        }
         NSMutableDictionary *newDict = [[NSMutableDictionary alloc] init];
         for (NSString *key in [obj allKeys]) {
             [newDict setObject:formatJSToOC(jsval[key]) forKey:key];


### PR DESCRIPTION
当hook住返回值为block类型的函数时会出现崩溃。原因是formatJSToOC中没有判断转换block类型。