### PR TITLE
fix  self.super()   testCase

### DIFF
--- a/JSPatchDemo/JSPatchTests/JSPatchTests.m
+++ b/JSPatchDemo/JSPatchTests/JSPatchTests.m
@@ -180,6 +180,7 @@
     [self loadPatch:@"superTest"];
     SuperTestC *testobject = [[SuperTestC alloc]init];
     [testobject testSuper];
+    XCTAssert(testobject.hasTestSuperA);
 }
 
 - (void)testInheritance

--- a/JSPatchDemo/JSPatchTests/SuperTestObject.h
+++ b/JSPatchDemo/JSPatchTests/SuperTestObject.h
@@ -10,6 +10,8 @@
 
 
 @interface SuperTestA : NSObject
+
+@property (nonatomic,assign) BOOL hasTestSuperA;
 -(void)testSuper;
 @end
 

--- a/JSPatchDemo/JSPatchTests/SuperTestObject.m
+++ b/JSPatchDemo/JSPatchTests/SuperTestObject.m
@@ -18,9 +18,18 @@
 @end
 
 @implementation SuperTestA
+-(instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.hasTestSuperA = NO;
+    }
+    return self;
+}
 
 -(void)testSuper
 {
+    self.hasTestSuperA = YES;
     NSLog(@" === print test A ====");
 }
 


### PR DESCRIPTION
以前的testCase 循环调用 不会 assert fail 依然是判定success 不合理

现在的testCase 会明确判断 super 调用后 造成的hasTestSuperA 是否产生了变化