### PR TITLE
change the way that judging js function's existence

### DIFF
--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -571,9 +571,8 @@ static void JPForwardInvocation(__unsafe_unretained id assignSlf, SEL selector, 
     
     NSString *selectorName = NSStringFromSelector(invocation.selector);
     NSString *JPSelectorName = [NSString stringWithFormat:@"_JP%@", selectorName];
-    SEL JPSelector = NSSelectorFromString(JPSelectorName);
-    
-    if (!class_respondsToSelector(object_getClass(slf), JPSelector)) {
+    JSValue *jsFunc = _JSOverideMethods[object_getClass(slf)][JPSelectorName];
+    if (!jsFunc) {
         JPExcuteORIGForwardInvocation(slf, selector, invocation);
         return;
     }
@@ -920,12 +919,9 @@ static void overrideMethod(Class cls, NSString *selectorName, JSValue *function,
     }
     
     NSString *JPSelectorName = [NSString stringWithFormat:@"_JP%@", selectorName];
-    SEL JPSelector = NSSelectorFromString(JPSelectorName);
-
+    
     _initJPOverideMethods(cls);
     _JSOverideMethods[cls][JPSelectorName] = function;
-    
-    class_addMethod(cls, JPSelector, msgForwardIMP, typeDescription);
 }
 
 #pragma mark -

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -552,7 +552,6 @@ static JSValue* getJSFunctionInObjectHierachy(id slf, NSString *selectorName)
     while (!func) {
         cls = class_getSuperclass(cls);
         if (!cls) {
-            NSCAssert(NO, @"warning can not find selector %@", selectorName);
             return nil;
         }
         func = _JSOverideMethods[cls][selectorName];
@@ -571,7 +570,7 @@ static void JPForwardInvocation(__unsafe_unretained id assignSlf, SEL selector, 
     
     NSString *selectorName = NSStringFromSelector(invocation.selector);
     NSString *JPSelectorName = [NSString stringWithFormat:@"_JP%@", selectorName];
-    JSValue *jsFunc = _JSOverideMethods[object_getClass(slf)][JPSelectorName];
+    JSValue *jsFunc = getJSFunctionInObjectHierachy(slf, JPSelectorName);
     if (!jsFunc) {
         JPExcuteORIGForwardInvocation(slf, selector, invocation);
         return;


### PR DESCRIPTION
比如JSPatch修改的方法名为CustomMethod。
之前的实现中，会向目标类中添加_JPCustomMethod方法，IMP为_objc_msgForward。
发送CustomMethod消息时，会调用JPForwardInvocation。JPForwardInvocation中通过判断是否存在_JPCustomMethod SEL，决定是否存在相应的js函数。

按自己的理解作了下面的图。
[http://7xilqo.com1.z0.glb.clouddn.com/temp_JSPatch_MessageSend.png](http://7xilqo.com1.z0.glb.clouddn.com/temp_JSPatch_MessageSend.png)

如果向目标类中添加_JPCustomMethod这个方法仅为这个作用，觉得是不需要的。
1. JSPatch提供给使用者的说明是：会额外添加一个ORIGCustomMethod，以便调用原来的方法实现。除非必要，不应该增加其它的SEL及IMP。
2. JSPatch修改的方法实现为js函数，保存在全局变量_JSOverideMethods，应该通过访问该变量判断方法实现是否存在。
