### PR TITLE
Fix overrideMethod threading issue

### DIFF
--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -911,8 +911,6 @@ static void overrideMethod(Class cls, NSString *selectorName, JSValue *function,
         }
     #endif
 
-    class_replaceMethod(cls, selector, msgForwardIMP, typeDescription);
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
     if (class_getMethodImplementation(cls, @selector(forwardInvocation:)) != (IMP)JPForwardInvocation) {
@@ -936,6 +934,10 @@ static void overrideMethod(Class cls, NSString *selectorName, JSValue *function,
     _JSOverideMethods[cls][JPSelectorName] = function;
     
     class_addMethod(cls, JPSelector, msgForwardIMP, typeDescription);
+
+    // Replace the original secltor at last, preventing threading issus when
+    // the selector get called during the execution of `overrideMethod`
+    class_replaceMethod(cls, selector, msgForwardIMP, typeDescription);
 }
 
 #pragma mark -


### PR DESCRIPTION
我们在替换经常被调用的方法时发现了一个问题，在 `overrideMethod` 被调用的时候，如果其他线程调用了正在被覆盖的方法，可能会导致崩溃，崩溃堆栈如下：

> 2016-05-18 17:12:35.463 JSPatchDemo[35709:7064368] -[AppDelegate testMethod]: unrecognized selector sent to instance 0x7ff56970a160
> 2016-05-18 17:12:35.466 JSPatchDemo[35709:7064368] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[AppDelegate testMethod]: unrecognized selector sent to instance 0x7ff56970a160'
> *** First throw call stack:
> (
> 	0   CoreFoundation                      0x0000000110ed8d85 __exceptionPreprocess + 165
> 	1   libobjc.A.dylib                     0x000000011094adeb objc_exception_throw + 48
> 	2   CoreFoundation                      0x0000000110ee1d3d -[NSObject(NSObject) doesNotRecognizeSelector:] + 205
> 	3   CoreFoundation                      0x0000000110dc15cc __invoking___ + 140
> 	4   CoreFoundation                      0x0000000110dc141e -[NSInvocation invoke] + 286
> 	5   JSPatchDemo                         0x000000010fc81a32 JPExcuteORIGForwardInvocation + 898
> 	6   JSPatchDemo                         0x000000010fc72e83 JPForwardInvocation + 355
> 	7   CoreFoundation                      0x0000000110e27b17 ___forwarding___ + 487
> 	8   CoreFoundation                      0x0000000110e278a8 _CF_forwarding_prep_0 + 120
> 	9   JSPatchDemo                         0x000000010fc61f0b __57-[AppDelegate application:didFinishLaunchingWithOptions:]_block_invoke + 43
> 	10  libdispatch.dylib                   0x0000000113072d9d _dispatch_call_block_and_release + 12
> 	11  libdispatch.dylib                   0x00000001130933eb _dispatch_client_callout + 8
> 	12  libdispatch.dylib                   0x000000011307bb2f _dispatch_root_queue_drain + 1829
> 	13  libdispatch.dylib                   0x000000011307b405 _dispatch_worker_thread3 + 111
> 	14  libsystem_pthread.dylib             0x00000001133e74de _pthread_wqthread + 1129
> 	15  libsystem_pthread.dylib             0x00000001133e5341 start_wqthread + 13
> )
> libc++abi.dylib: terminating with uncaught exception of type NSException

可以引起崩溃的示例代码可以在 https://github.com/leafduo/JSPatch/commit/5c773d98c9fec99f479e31f89cec56e3aab7aa62 找到，运行十几次之后大概可以触发一次崩溃。

查阅代码之后，我们发现把 selector 的替换放在 `overrideMethod` 的最后可以解决这个问题，也就是说把准备工作做好之后再把入口替换掉。