### PR TITLE
Fix an iOS7 bug.  [NSInvocation getReturnValue] return 0 when the ret…

### DIFF
--- a/Demo/iOSDemo/JSPatchTests/JPTestObject.h
+++ b/Demo/iOSDemo/JSPatchTests/JPTestObject.h
@@ -13,6 +13,7 @@
 - (void)funcWithInt:(int)intValue;
 @property (nonatomic, assign) BOOL funcReturnVoidPassed;
 @property (nonatomic, assign) BOOL funcReturnStringPassed;
+@property (nonatomic, assign) BOOL funcReturnDoublePassed;
 @property (nonatomic, assign) BOOL funcReturnViewWithFramePassed;
 @property (nonatomic, assign) BOOL funcWithViewAndReturnViewPassed;
 
@@ -82,6 +83,7 @@
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnObjPassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnObjCalledOriginalPassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnIntPassed;
+@property (nonatomic, assign) BOOL classFuncToSwizzleReturnDoublePassed;
 
 
 @property (nonatomic, assign) BOOL funcCallSuperPassed;

--- a/Demo/iOSDemo/JSPatchTests/JPTestObject.m
+++ b/Demo/iOSDemo/JSPatchTests/JPTestObject.m
@@ -19,6 +19,10 @@
     return @"stringFromOC";
 }
 
+- (double)funcReturnDouble {
+    return 100.0;
+}
+
 - (CGRect)funcWithRectAndReturnRect:(CGRect)rect
 {
     return rect;
@@ -219,6 +223,11 @@ typedef struct {
     int retI = [JPTestObject classFuncToSwizzleReturnInt:42];
     if (retI == 42) {
         self.classFuncToSwizzleReturnIntPassed = YES;
+    }
+    
+    double retD = [JPTestObject classFuncToSwizzleReturnDouble:100.0];
+    if (fabs(retD - 100.0) < FLT_EPSILON) {
+        self.classFuncToSwizzleReturnDoublePassed = YES;
     }
     
     [self funcToSwizzleWithBlock:^(UIView *view, int num) {
@@ -446,7 +455,10 @@ typedef NSString * (^JSBlock)(NSError *);
     return 0;
 }
 
-
++ (double)classFuncToSwizzleReturnDouble:(double)d
+{
+    return 0;
+}
 
 
 #pragma mark - super

--- a/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
+++ b/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
@@ -53,6 +53,10 @@
     
     XCTAssert(obj.funcReturnStringPassed, @"funcReturnStringPassed");
     
+    // Test for functions which return double/float, cause there's a fatal bug in NSInvocation on iOS7.0
+    // This case shall fail if you comment line 957~959 in JPEngine.m on iOS7.0.
+    XCTAssert(obj.funcReturnDoublePassed, @"funcReturnDoublePassed");
+    
     XCTAssert(obj.funcWithIntPassed, @"funcWithIntPassed");
     XCTAssert(obj.funcWithNilPassed, @"funcWithNilPassed");
     XCTAssert(obj.funcReturnNilPassed, @"funcReturnNilPassed");
@@ -139,6 +143,9 @@
     XCTAssert(obj.classFuncToSwizzleReturnObjPassed, @"classFuncToSwizzleReturnObjPassed");
     XCTAssert(obj.classFuncToSwizzleReturnObjCalledOriginalPassed, @"classFuncToSwizzleReturnObjCalledOriginalPassed");
     XCTAssert(obj.classFuncToSwizzleReturnIntPassed, @"classFuncToSwizzleReturnIntPassed");
+    // Test for functions which return double/float, cause there's a fatal bug in NSInvocation on iOS7.0
+    // This case shall fail if you comment line 1050~1052 in JPEngine.m on iOS7.0.
+    XCTAssert(obj.classFuncToSwizzleReturnDoublePassed, @"classFuncToSwizzleReturnDoublePassed");
     
     XCTAssert(subObj.funcCallSuperSubObjectPassed, @"funcCallSuperSubObjectPassed");
     XCTAssert(subObj.funcCallSuperPassed, @"funcCallSuperPassed");

--- a/Demo/iOSDemo/JSPatchTests/test.js
+++ b/Demo/iOSDemo/JSPatchTests/test.js
@@ -101,6 +101,10 @@ require('JPEngine').defineStruct({
     },
     classFuncToSwizzleReturnInt: function(i) {
       return i
+    },
+    ///////Test for function which return double/float, cause there's a fatal bug in NSInvocation on iOS7.0
+    classFuncToSwizzleReturnDouble: function(d) {
+      return d
     }
   })
 
@@ -122,6 +126,11 @@ require('JPEngine').defineStruct({
   obj.funcReturnVoid();
   var testReturnString = obj.funcReturnString().toJS();
   obj.setFuncReturnStringPassed(testReturnString == "stringFromOC")
+
+  ///////Test for functions which return double/float, cause there's a fatal bug in NSInvocation on iOS7.0
+  var testReturnDouble = obj.funcReturnDouble()
+  console.log(testReturnDouble == 100)
+  obj.setFuncReturnDoublePassed(testReturnDouble == 100)
 
   obj.funcWithInt(42);
   obj.funcWithDict_andDouble({test: "test"}, 4.2)

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -46,6 +46,54 @@ JPBOXING_GEN(boxAssignObj, assignObj, id)
 }
 @end
 
+#pragma mark - Fix NSInvocation fatal error
+
+typedef struct {double d;} JPDouble;
+typedef struct {float f;} JPFloat;
+
+@interface NSObject (JPFix)
+- (NSMethodSignature *)jp_methodSignatureForSelector:(SEL)aSelector;
++ (void)jp_fixMethodSignature;
+@end
+@implementation NSObject (JPFix)
+
+const static void *JPFixedFlagKey = &JPFixedFlagKey;
+
+- (NSMethodSignature *)jp_methodSignatureForSelector:(SEL)aSelector {
+    NSMethodSignature *signature = [self jp_methodSignatureForSelector:aSelector];
+#ifdef __LP64__
+    BOOL isReturnDouble = (strcmp([signature methodReturnType], "d") == 0);
+    BOOL isReturnFloat = (strcmp([signature methodReturnType], "f") == 0);
+    
+    if (isReturnDouble || isReturnFloat) {
+        NSMutableString *types = [NSMutableString stringWithFormat:@"%s@:", isReturnDouble ? @encode(JPDouble) : @encode(JPFloat)];
+        for (int i = 2; i < signature.numberOfArguments; i++) {
+            const char *argType = [signature getArgumentTypeAtIndex:i];
+            [types appendFormat:@"%s", argType];
+        }
+        signature = [NSMethodSignature signatureWithObjCTypes:[types UTF8String]];
+    }
+#endif
+    return signature;
+}
++ (void)jp_fixMethodSignature {
+    NSNumber *flag = objc_getAssociatedObject(self, JPFixedFlagKey);
+    if (!flag.boolValue) {
+        SEL originalSelector = @selector(methodSignatureForSelector:);
+        SEL swizzledSelector = @selector(jp_methodSignatureForSelector:);
+        Method originalMethod = class_getInstanceMethod(self, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(self, swizzledSelector);
+        BOOL didAddMethod = class_addMethod(self, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod));
+        if (didAddMethod) {
+            class_replaceMethod(self, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+        objc_setAssociatedObject(self, JPFixedFlagKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+@end
+
 static JSContext *_context;
 static NSString *_regexStr = @"(?<!\\\\)\\.\\s*(\\w+)\\s*\\(";
 static NSString *_replaceStr = @".__c(\"$1\")(";
@@ -691,7 +739,16 @@ static void JPForwardInvocation(__unsafe_unretained id assignSlf, SEL selector, 
     }
     
     NSArray *params = _formatOCToJSList(argList);
-    const char *returnType = [methodSignature methodReturnType];
+    char returnType[255];
+    strcpy(returnType, [methodSignature methodReturnType]);
+    
+    // Restore the return type
+    if (strcmp(returnType, @encode(JPDouble)) == 0) {
+        strcpy(returnType, @encode(double));
+    }
+    if (strcmp(returnType, @encode(JPFloat)) == 0) {
+        strcpy(returnType, @encode(float));
+    }
 
     switch (returnType[0] == 'r' ? returnType[1] : returnType[0]) {
         #define JP_FWD_RET_CALL_JS \
@@ -893,6 +950,13 @@ static void overrideMethod(Class cls, NSString *selectorName, JSValue *function,
         }
     }
 #pragma clang diagnostic pop
+    
+    // A fatal error of NSInvocation on iOS7.0.
+    // A invocation return 0 when the return type is double/float.
+    // http://stackoverflow.com/questions/19874502/nsinvocation-getreturnvalue-with-double-value-produces-0-unexpectedly
+    if ([[UIDevice currentDevice].systemVersion compare:@"7.1"] == NSOrderedAscending) {
+        [cls jp_fixMethodSignature];
+    }
 
     if (class_respondsToSelector(cls, selector)) {
         NSString *originalSelectorName = [NSString stringWithFormat:@"ORIG%@", selectorName];


### PR DESCRIPTION
Fix an iOS7 bug. [NSInvocation getReturnValue] return 0 when the return type is double/float.
Fix issue #162.