### PR TITLE
fix bug, the new property is null,then it will crash when null call method

### DIFF
--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -98,6 +98,9 @@ var global = this
           if (methodName.length > 3 && methodName.substr(0,3) == 'set' && c >= 65 && c <= 90) {
             return function(val) {
               var propName = methodName[3].toLowerCase() + methodName.substr(4)
+              if(val === undefined || val === null) {
+                val = false;
+              }
               slf.__ocProps[propName] = val
             }
           } else {


### PR DESCRIPTION
描述：使用JSPatch 添加新属性， 调用属性的set方法，赋值为null， 此时取出的值也为null， JS中通过null 调用方法 就会发生crash，如果对新增属性来说，此bug复现程度还是蛮高的 

解决办法： 在给属性赋值的时候判断 是否为undefined 或 null，  如果是 则赋值为false。 那么判断条件为什么不是!val 呢，  因为 val 可能是0等 非对象的值， 会导致赋值错误！