### PR TITLE
refine rewriting the invocation of a block with scalar-type args with JS

### DIFF
--- a/Extensions/JPCFunction/JPMemory.m
+++ b/Extensions/JPCFunction/JPMemory.m
@@ -99,6 +99,41 @@
         *((__unsafe_unretained id *)m) = obj;
     };
     
+    context[@"assignScalarTypePointer"] = ^void(JSValue *jsVal, JSValue *value, NSString *type) {
+        void *pointer = [self formatPointerJSToOC:jsVal];
+        char *typeChar = (char*)[type UTF8String];
+        
+        switch (typeChar[0]) {
+            #define JP_ASSIGN_SCALAR_CASE(_typeChar, _type, _method) \
+            case _typeChar: {   \
+                NSNumber *num = [value toNumber]; \
+                (*(_type *)pointer) = [num _method]; \
+                break;  \
+            }
+                
+            JP_ASSIGN_SCALAR_CASE('s', short, shortValue)
+            JP_ASSIGN_SCALAR_CASE('S', unsigned short, unsignedShortValue)
+            JP_ASSIGN_SCALAR_CASE('i', int, intValue)
+            JP_ASSIGN_SCALAR_CASE('I', unsigned int, unsignedIntValue)
+            JP_ASSIGN_SCALAR_CASE('l', long, longValue)
+            JP_ASSIGN_SCALAR_CASE('L', unsigned long, unsignedLongValue)
+            JP_ASSIGN_SCALAR_CASE('q', long long, longLongValue)
+            JP_ASSIGN_SCALAR_CASE('Q', unsigned long long, unsignedLongLongValue)
+            JP_ASSIGN_SCALAR_CASE('f', float, floatValue)
+            JP_ASSIGN_SCALAR_CASE('d', double, doubleValue)
+            JP_ASSIGN_SCALAR_CASE('B', BOOL, boolValue)
+            case 'c': 
+            case 'C': {
+                NSString *str = [value toString];
+                (*(char *)pointer) = *[str cStringUsingEncoding:NSUTF8StringEncoding];
+                break;
+            }
+            default: {
+                break;
+            }
+        }
+    };
+    
     context[@"autoreleasepool"] = ^void(JSValue *cb) {
         @autoreleasepool {
             [cb callWithArguments:nil];

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -1396,7 +1396,10 @@ static id genCallbackBlock(JSValue *jsVal)
 {
     #define BLK_TRAITS_ARG(_idx, _paramName) \
     if (_idx < argTypes.count) { \
-        if (blockTypeIsObject(trim(argTypes[_idx]))) {  \
+        NSString *argType = trim(argTypes[_idx]); \
+        if (blockTypeIsSCalarPointer(argType)) { \
+            [list addObject:formatOCToJS([JPBoxing boxPointer:_paramName])]; \
+        } else if (blockTypeIsObject(trim(argTypes[_idx]))) {  \
             [list addObject:formatOCToJS((__bridge id)_paramName)]; \
         } else {  \
             [list addObject:formatOCToJS([NSNumber numberWithLongLong:(long long)_paramName])]; \
@@ -1594,6 +1597,15 @@ static NSString *trim(NSString *string)
 static BOOL blockTypeIsObject(NSString *typeString)
 {
     return [typeString rangeOfString:@"*"].location != NSNotFound || [typeString isEqualToString:@"id"];
+}
+
+static BOOL blockTypeIsSCalarPointer(NSString *typeString)
+{
+    NSUInteger location = [typeString rangeOfString:@"*"].location;
+    NSString *typeWithoutAsterisk = trim([typeString stringByReplacingOccurrencesOfString:@"*" withString:@""]);
+    
+    return (location == typeString.length-1 &&
+            !NSClassFromString(typeWithoutAsterisk));
 }
 
 static NSString *convertJPSelectorString(NSString *selectorString)


### PR DESCRIPTION
这个提交是源自这个问题: 
用JS重写调用类似enumerateLinesUsingBlock:方法时会crash。
 #515  : )