### PR TITLE
不使用debugDescription来判断是否使用_objc_msgForward_stret

### DIFF
--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -974,9 +974,11 @@ static void overrideMethod(Class cls, NSString *selectorName, JSValue *function,
         if (typeDescription[0] == '{') {
             //In some cases that returns struct, we should use the '_stret' API:
             //http://sealiesoftware.com/blog/archive/2008/10/30/objc_explain_objc_msgSend_stret.html
-            //NSMethodSignature knows the detail but has no API to return, we can only get the info from debugDescription.
-            NSMethodSignature *methodSignature = [NSMethodSignature signatureWithObjCTypes:typeDescription];
-            if ([methodSignature.debugDescription rangeOfString:@"is special struct return? YES"].location != NSNotFound) {
+            //Inspired by Aspects, and correct a mistake. Apple's document has information about how to deal with such problem
+            //https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/LowLevelABI/100-32-bit_PowerPC_Function_Calling_Conventions/32bitPowerPC.html#//apple_ref/doc/uid/TP40002438-SW13
+            NSUInteger valueSize = 0;
+            NSGetSizeAndAlignment(typeDescription, &valueSize, NULL);
+            if (valueSize > 4) {
                 msgForwardIMP = (IMP)_objc_msgForward_stret;
             }
         }


### PR DESCRIPTION
https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/LowLevelABI/100-32-bit_PowerPC_Function_Calling_Conventions/32bitPowerPC.html#//apple_ref/doc/uid/TP40002438-SW13
根据上述文档Returning Results章节的描述“Composite values (such as struct and union) and values larger than 4 bytes are placed at the location pointed to by GPR3. See Passing Arguments for more information.”，所以如果返回值是struct，可以通过判断struct的大小来决定使用哪个函数