### PR TITLE
使用struct返回值的大小来判断是否使用_objc_msgForward_stret

### DIFF
--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -974,9 +974,11 @@ static void overrideMethod(Class cls, NSString *selectorName, JSValue *function,
         if (typeDescription[0] == '{') {
             //In some cases that returns struct, we should use the '_stret' API:
             //http://sealiesoftware.com/blog/archive/2008/10/30/objc_explain_objc_msgSend_stret.html
-            //NSMethodSignature knows the detail but has no API to return, we can only get the info from debugDescription.
-            NSMethodSignature *methodSignature = [NSMethodSignature signatureWithObjCTypes:typeDescription];
-            if ([methodSignature.debugDescription rangeOfString:@"is special struct return? YES"].location != NSNotFound) {
+            //Inspired by Aspects, and correct a mistake. <<AAPCS - 5.4 Result Return>> has information about how to deal with such problem
+            //http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042f/IHI0042F_aapcs.pdf
+            NSUInteger valueSize = 0;
+            NSGetSizeAndAlignment(typeDescription, &valueSize, NULL);
+            if (valueSize > 4) {
                 msgForwardIMP = (IMP)_objc_msgForward_stret;
             }
         }


### PR DESCRIPTION
根据《iOS ABI Function Call Guide》显示编译器遵循AAPCS的规定，根据AAPCS文档《Result Return》章节的描述：一个Composite Type（包括struct）返回值的大小如果大于4 bytes则不会直接存储在寄存器中