### PR TITLE
去除对libffi.a的编译

### DIFF
--- a/JSPatch.podspec
+++ b/JSPatch.podspec
@@ -42,14 +42,14 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "JPCFunction" do |ss|
-    ss.ios.source_files = "Extensions/JPCFunction/**/*", "Extensions/JPLibffi/**/*" 
+    ss.ios.source_files = "Extensions/JPCFunction/**/*", "Extensions/JPLibffi/**/*.{h,m}" 
     ss.ios.public_header_files = "Extensions/JPCFunction/**/*.h", "Extensions/JPLibffi/**/*.h" 
     ss.vendored_libraries = 'Extensions/JPLibffi/libffi/libffi.a'
     ss.dependency 'JSPatch/Core'
   end
 
   s.subspec "JPBlock" do |ss|
-    ss.ios.source_files = "Extensions/JPBlock/**/*", "Extensions/JPLibffi/**/*" 
+    ss.ios.source_files = "Extensions/JPBlock/**/*", "Extensions/JPLibffi/**/*.{h,m}" 
     ss.ios.public_header_files = "Extensions/JPBlock/**/*.h", "Extensions/JPLibffi/**/*.h" 
     ss.vendored_libraries = 'Extensions/JPLibffi/libffi/libffi.a'
     ss.dependency 'JSPatch/Core'


### PR DESCRIPTION
不加文件类型的限制的话，会把libffi目录下的libffi.a文件也加到Compile Sources里去，Xcode编译时会报没有libffi.a文件的编译规则的警告