### PR TITLE
C function supports Struct type

### DIFF
--- a/Demo/iOSDemo/JSPatchTests/JPCFunctionTest.h
+++ b/Demo/iOSDemo/JSPatchTests/JPCFunctionTest.h
@@ -10,6 +10,7 @@
 
 @interface JPCFunctionTest : NSObject
 + (BOOL)testCfuncWithCGSize;
++ (BOOL)testCfuncWithCGRect;
 + (BOOL)testCfuncWithId;
 + (BOOL)testCfuncWithInt;
 + (BOOL)testCfuncWithCGFloat;

--- a/Demo/iOSDemo/JSPatchTests/JPCFunctionTest.h
+++ b/Demo/iOSDemo/JSPatchTests/JPCFunctionTest.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @interface JPCFunctionTest : NSObject
++ (BOOL)testCfuncWithCGSize;
 + (BOOL)testCfuncWithId;
 + (BOOL)testCfuncWithInt;
 + (BOOL)testCfuncWithCGFloat;

--- a/Demo/iOSDemo/JSPatchTests/JPCFunctionTest.m
+++ b/Demo/iOSDemo/JSPatchTests/JPCFunctionTest.m
@@ -12,6 +12,10 @@
 
 static bool voidFuncRet = false;
 
+CGSize cfuncWithCGSize(CGSize size){
+    return size;
+}
+
 id cfuncWithId(NSString *str){
     return str;
 }
@@ -37,6 +41,9 @@ void cfuncVoid() {
 }
 
 @implementation JPCFunctionTest
++ (BOOL)testCfuncWithCGSize{
+    return NO;
+}
 + (BOOL)testCfuncWithId{
     return NO;
 };

--- a/Demo/iOSDemo/JSPatchTests/JPCFunctionTest.m
+++ b/Demo/iOSDemo/JSPatchTests/JPCFunctionTest.m
@@ -16,6 +16,10 @@ CGSize cfuncWithCGSize(CGSize size){
     return size;
 }
 
+CGRect cfuncWithCGRect(CGRect rect){
+    return rect;
+}
+
 id cfuncWithId(NSString *str){
     return str;
 }
@@ -42,6 +46,9 @@ void cfuncVoid() {
 
 @implementation JPCFunctionTest
 + (BOOL)testCfuncWithCGSize{
+    return NO;
+}
++ (BOOL)testCfuncWithCGRect{
     return NO;
 }
 + (BOOL)testCfuncWithId{

--- a/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
+++ b/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
@@ -287,6 +287,7 @@
 {
     [self loadPatch:@"jsCFunctionTest"];
     XCTAssert([JPCFunctionTest testCfuncWithCGSize], @"testCfuncWithCGSize");
+    XCTAssert([JPCFunctionTest testCfuncWithCGRect], @"testCfuncWithCGRect");
     XCTAssert([JPCFunctionTest testCfuncWithId], @"testCfuncWithId");
     XCTAssert([JPCFunctionTest testCfuncWithInt], @"testCfuncWithInt");
     XCTAssert([JPCFunctionTest testCfuncWithCGFloat], @"testCfuncWithCGFloat");

--- a/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
+++ b/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
@@ -286,6 +286,7 @@
 - (void)testCFunction
 {
     [self loadPatch:@"jsCFunctionTest"];
+    XCTAssert([JPCFunctionTest testCfuncWithCGSize], @"testCfuncWithCGSize");
     XCTAssert([JPCFunctionTest testCfuncWithId], @"testCfuncWithId");
     XCTAssert([JPCFunctionTest testCfuncWithInt], @"testCfuncWithInt");
     XCTAssert([JPCFunctionTest testCfuncWithCGFloat], @"testCfuncWithCGFloat");

--- a/Demo/iOSDemo/JSPatchTests/jsCFunctionTest.js
+++ b/Demo/iOSDemo/JSPatchTests/jsCFunctionTest.js
@@ -4,12 +4,28 @@ require('JPEngine').defineStruct({
     "types": "FF",
     "keys": ["width", "height"]
 });
+require('JPEngine').defineStruct({
+    "name": "CGPoint",
+    "types": "FF",
+    "keys": ["x", "y"]
+});
+require('JPEngine').defineStruct({
+    "name": "CGRect",
+    "types": "{CGPoint}{CGSize}",
+    "keys": ["origin", "size"]
+});
 
 defineClass('JPCFunctionTest', {}, {
     testCfuncWithCGSize: function() {
         defineCFunction("cfuncWithCGSize", "{CGSize}, {CGSize}")
         var ret = cfuncWithCGSize({width:1, height:2});
         return ret.width == 1 && ret.height == 2;
+    },
+    testCfuncWithCGRect: function() {
+        defineCFunction("cfuncWithCGRect", "{CGRect}, {CGRect}")
+        var ret = cfuncWithCGRect({origin:{x:1,y:2},size:{width:3, height:4}});
+        console.log("testCfuncWithCGRect", JSON.stringify(ret), ret.origin, ret.origin.x);
+        return ret.origin.x == 1 && ret.origin.y == 2 && ret.size.width == 3 && ret.size.height == 4;
     },
     testCfuncWithId: function() {
         defineCFunction("cfuncWithId", "id, NSString *")

--- a/Demo/iOSDemo/JSPatchTests/jsCFunctionTest.js
+++ b/Demo/iOSDemo/JSPatchTests/jsCFunctionTest.js
@@ -1,6 +1,16 @@
 require('JPEngine').addExtensions(['JPCFunction'])
+require('JPEngine').defineStruct({
+    "name": "CGSize",
+    "types": "FF",
+    "keys": ["width", "height"]
+});
 
 defineClass('JPCFunctionTest', {}, {
+    testCfuncWithCGSize: function() {
+        defineCFunction("cfuncWithCGSize", "{CGSize}, {CGSize}")
+        var ret = cfuncWithCGSize({width:1, height:2});
+        return ret.width == 1 && ret.height == 2;
+    },
     testCfuncWithId: function() {
         defineCFunction("cfuncWithId", "id, NSString *")
         var ret = cfuncWithId("JSPatch");

--- a/Extensions/JPCFunction/JPCFunction.m
+++ b/Extensions/JPCFunction/JPCFunction.m
@@ -107,11 +107,14 @@ static NSMutableDictionary *_funcDefines;
         }
         case '{': {
             NSString *structName = [NSString stringWithCString:typeString encoding:NSASCIIStringEncoding];
-            structName = [structName substringWithRange:NSMakeRange(1, structName.length - 2)];
-            NSDictionary *structDefine = [JPExtension registeredStruct][structName];
-            id dict = [JPExtension getDictOfStruct:src structDefine:structDefine];
-            id ret = [JSValue valueWithObject:dict inContext:[JPEngine context]];
-            return ret;
+            NSUInteger end = [structName rangeOfString:@"}"].location;
+            if (end != NSNotFound) {
+                structName = [structName substringWithRange:NSMakeRange(1, end - 1)];
+                NSDictionary *structDefine = [JPExtension registeredStruct][structName];
+                id dict = [JPExtension getDictOfStruct:src structDefine:structDefine];
+                id ret = [JSValue valueWithObject:dict inContext:[JPEngine context]];
+                return ret;
+            }
         }
         default:
             return nil;
@@ -153,10 +156,13 @@ static NSMutableDictionary *_funcDefines;
         }
         case '{': {
             NSString *structName = [NSString stringWithCString:typeString encoding:NSASCIIStringEncoding];
-            structName = [structName substringWithRange:NSMakeRange(1, structName.length - 2)];
-            NSDictionary *structDefine = [JPExtension registeredStruct][structName];
-            [JPExtension getStructDataWidthDict:dist dict:object structDefine:structDefine];
-            break;
+            NSUInteger end = [structName rangeOfString:@"}"].location;
+            if (end != NSNotFound) {
+                structName = [structName substringWithRange:NSMakeRange(1, end - 1)];
+                NSDictionary *structDefine = [JPExtension registeredStruct][structName];
+                [JPExtension getStructDataWidthDict:dist dict:object structDefine:structDefine];
+                break;
+            }
         }
         default:
             break;

--- a/Extensions/JPCFunction/JPCFunction.m
+++ b/Extensions/JPCFunction/JPCFunction.m
@@ -11,6 +11,13 @@
 #import <dlfcn.h>
 #import "JPMethodSignature.h"
 
+#if CGFLOAT_IS_DOUBLE
+#define CGFloatValue doubleValue
+#define numberWithCGFloat numberWithDouble
+#else
+#define CGFloatValue floatValue
+#define numberWithCGFloat numberWithFloat
+#endif
 
 @implementation JPCFunction
 
@@ -50,17 +57,110 @@ static NSMutableDictionary *_funcDefines;
         NSString *typeStr = trim([typeArr objectAtIndex:i]);
         NSString *encode = [JPMethodSignature typeEncodeWithTypeName:typeStr];
         if (!encode) {
-            NSString *argClassName = trim([typeStr stringByReplacingOccurrencesOfString:@"*" withString:@""]);
-            if (NSClassFromString(argClassName) != NULL) {
-                encode = @"@";
+            if ([typeStr hasPrefix:@"{"] && [typeStr hasSuffix:@"}"]) {
+                encode = typeStr;
             } else {
-                NSCAssert(NO, @"unreconized type %@", typeStr);
-                return;
+                NSString *argClassName = trim([typeStr stringByReplacingOccurrencesOfString:@"*" withString:@""]);
+                if (NSClassFromString(argClassName) != NULL) {
+                    encode = @"@";
+                } else {
+                    NSCAssert(NO, @"unreconized type %@", typeStr);
+                    return;
+                }
             }
         }
         [encodeStr appendString:encode];
     }
     [_funcDefines setObject:encodeStr forKey:funcName];
+}
+
++ (id)objectWithCValue:(void *)src forType:(const char *)typeString
+{
+    switch (typeString[0]) {
+    #define JP_FFI_RETURN_CASE(_typeString, _type, _selector)\
+        case _typeString:{\
+            _type v = *(_type *)src;\
+            return [NSNumber _selector:v];\
+        }
+        JP_FFI_RETURN_CASE('c', char, numberWithChar)
+        JP_FFI_RETURN_CASE('C', unsigned char, numberWithUnsignedChar)
+        JP_FFI_RETURN_CASE('s', short, numberWithShort)
+        JP_FFI_RETURN_CASE('S', unsigned short, numberWithUnsignedShort)
+        JP_FFI_RETURN_CASE('i', int, numberWithInt)
+        JP_FFI_RETURN_CASE('I', unsigned int, numberWithUnsignedInt)
+        JP_FFI_RETURN_CASE('l', long, numberWithLong)
+        JP_FFI_RETURN_CASE('L', unsigned long, numberWithUnsignedLong)
+        JP_FFI_RETURN_CASE('q', long long, numberWithLongLong)
+        JP_FFI_RETURN_CASE('Q', unsigned long long, numberWithUnsignedLongLong)
+        JP_FFI_RETURN_CASE('f', float, numberWithFloat)
+        JP_FFI_RETURN_CASE('F', CGFloat, numberWithCGFloat)
+        JP_FFI_RETURN_CASE('d', double, numberWithDouble)
+        JP_FFI_RETURN_CASE('B', BOOL, numberWithBool)
+        case '^': {
+            JPBoxing *box = [[JPBoxing alloc] init];
+            box.pointer = (*(void**)src);
+            return box;
+        }
+        case '@':
+        case '#': {
+            return (__bridge id)(*(void**)src);
+        }
+        case '{': {
+            NSString *structName = [NSString stringWithCString:typeString encoding:NSASCIIStringEncoding];
+            structName = [structName substringWithRange:NSMakeRange(1, structName.length - 2)];
+            NSDictionary *structDefine = [JPExtension registeredStruct][structName];
+            id dict = [JPExtension getDictOfStruct:src structDefine:structDefine];
+            id ret = [JSValue valueWithObject:dict inContext:[JPEngine context]];
+            return ret;
+        }
+        default:
+            return nil;
+    }
+}
+
++ (void)convertObject:(id)object toCValue:(void *)dist forType:(const char *)typeString
+{
+#define JP_CALL_ARG_CASE(_typeString, _type, _selector)\
+    case _typeString:{\
+        *(_type *)dist = [(NSNumber *)object _selector];\
+        break;\
+    }
+    switch (typeString[0]) {
+        JP_CALL_ARG_CASE('c', char, charValue)
+        JP_CALL_ARG_CASE('C', unsigned char, unsignedCharValue)
+        JP_CALL_ARG_CASE('s', short, shortValue)
+        JP_CALL_ARG_CASE('S', unsigned short, unsignedShortValue)
+        JP_CALL_ARG_CASE('i', int, intValue)
+        JP_CALL_ARG_CASE('I', unsigned int, unsignedIntValue)
+        JP_CALL_ARG_CASE('l', long, longValue)
+        JP_CALL_ARG_CASE('L', unsigned long, unsignedLongValue)
+        JP_CALL_ARG_CASE('q', long long, longLongValue)
+        JP_CALL_ARG_CASE('Q', unsigned long long, unsignedLongLongValue)
+        JP_CALL_ARG_CASE('f', float, floatValue)
+        JP_CALL_ARG_CASE('F', CGFloat, CGFloatValue)
+        JP_CALL_ARG_CASE('d', double, doubleValue)
+        JP_CALL_ARG_CASE('B', BOOL, boolValue)
+        case '^': {
+            void *ptr = [((JPBoxing *)object) unboxPointer];
+            *(void **)dist = ptr;
+            break;
+        }
+        case '#':
+        case '@': {
+            id ptr = object;
+            *(void **)dist = (__bridge void *)(ptr);
+            break;
+        }
+        case '{': {
+            NSString *structName = [NSString stringWithCString:typeString encoding:NSASCIIStringEncoding];
+            structName = [structName substringWithRange:NSMakeRange(1, structName.length - 2)];
+            NSDictionary *structDefine = [JPExtension registeredStruct][structName];
+            [JPExtension getStructDataWidthDict:dist dict:object structDefine:structDefine];
+            break;
+        }
+        default:
+            break;
+    }
 }
 
 + (id)callCFunction:(NSString *)funcName arguments:(NSArray *)arguments
@@ -83,53 +183,10 @@ static NSMutableDictionary *_funcDefines;
         const char *argumentType = [funcSignature.argumentTypes[i] UTF8String];
         ffi_type *ffiType = [JPMethodSignature ffiTypeWithEncodingChar:argumentType];
         ffiArgTypes[i] = ffiType;
-        size_t typeSize = ffiType->size;
-        void *ffiArgPtr = alloca(typeSize);
-        
-        switch (argumentType[0]) {
-        #define JP_CALL_ARG_CASE(_typeString, _type, _selector) \
-            case _typeString: {                              \
-                _type *argPtr = ffiArgPtr;                     \
-                *argPtr = [(NSNumber *)arguments[i] _selector];\
-                break; \
-            }
-            
-            JP_CALL_ARG_CASE('c', char, charValue)
-            JP_CALL_ARG_CASE('C', unsigned char, unsignedCharValue)
-            JP_CALL_ARG_CASE('s', short, shortValue)
-            JP_CALL_ARG_CASE('S', unsigned short, unsignedShortValue)
-            JP_CALL_ARG_CASE('i', int, intValue)
-            JP_CALL_ARG_CASE('I', unsigned int, unsignedIntValue)
-            JP_CALL_ARG_CASE('l', long, longValue)
-            JP_CALL_ARG_CASE('L', unsigned long, unsignedLongValue)
-            JP_CALL_ARG_CASE('q', long long, longLongValue)
-            JP_CALL_ARG_CASE('Q', unsigned long long, unsignedLongLongValue)
-            JP_CALL_ARG_CASE('f', float, floatValue)
-            JP_CALL_ARG_CASE('d', double, doubleValue)
-            JP_CALL_ARG_CASE('B', BOOL, boolValue)
-                
-            case '^': {
-                void *ptr = [((JPBoxing *)arguments[i]) unboxPointer];
-                void **argPtr = ffiArgPtr;
-                *argPtr = ptr;
-                break;
-            }
-            case '#': {
-                id ptr = arguments[i];
-                void **argPtr = ffiArgPtr;
-                *argPtr = (__bridge void *)(ptr);
-                break;
-            }
-            case '@': {
-                id ptr = arguments[i];
-                void **argPtr = ffiArgPtr;
-                *argPtr = (__bridge void *)(ptr);
-                break;
-            }
-        }
+        void *ffiArgPtr = alloca(ffiType->size);
+        [self convertObject:arguments[i] toCValue:ffiArgPtr forType:argumentType];
         ffiArgs[i] = ffiArgPtr;
     }
-    
     
     ffi_cif cif;
     id ret = nil;
@@ -143,43 +200,9 @@ static NSMutableDictionary *_funcDefines;
             returnPtr = alloca(returnFfiType->size);
         }
         ffi_call(&cif, functionPtr, returnPtr, ffiArgs);
+
         if (returnFfiType->size) {
-            switch (returnTypeChar[0]) {
-            #define JP_FFI_RETURN_CASE(_typeString, _type, _selector) \
-                case _typeString: {                              \
-                    _type returnValue = *(_type *)returnPtr;                     \
-                    ret = [NSNumber _selector:returnValue];\
-                    break; \
-                }
-                JP_FFI_RETURN_CASE('c', char, numberWithChar)
-                JP_FFI_RETURN_CASE('C', unsigned char, numberWithUnsignedChar)
-                JP_FFI_RETURN_CASE('s', short, numberWithShort)
-                JP_FFI_RETURN_CASE('S', unsigned short, numberWithUnsignedShort)
-                JP_FFI_RETURN_CASE('i', int, numberWithInt)
-                JP_FFI_RETURN_CASE('I', unsigned int, numberWithUnsignedInt)
-                JP_FFI_RETURN_CASE('l', long, numberWithLong)
-                JP_FFI_RETURN_CASE('L', unsigned long, numberWithUnsignedLong)
-                JP_FFI_RETURN_CASE('q', long long, numberWithLongLong)
-                JP_FFI_RETURN_CASE('Q', unsigned long long, numberWithUnsignedLongLong)
-                JP_FFI_RETURN_CASE('f', float, numberWithFloat)
-                JP_FFI_RETURN_CASE('d', double, numberWithDouble)
-                JP_FFI_RETURN_CASE('B', BOOL, numberWithBool)
-                    
-                case '@': {
-                    ret = (__bridge id)(*(void**)returnPtr);
-                    break;
-                }
-                case '^': {
-                    JPBoxing *box = [[JPBoxing alloc] init];
-                    box.pointer = (*(void**)returnPtr);
-                    ret = box;
-                    break;
-                }
-                case '#': {
-                    ret = (__bridge id)(*(void**)returnPtr);
-                    break;
-                }
-            }
+            ret = [self objectWithCValue:returnPtr forType:returnTypeChar];
         }
     }
     

--- a/Extensions/JPLibffi/JPMethodSignature.m
+++ b/Extensions/JPLibffi/JPMethodSignature.m
@@ -8,6 +8,7 @@
 
 #import "JPMethodSignature.h"
 #import <UIKit/UIKit.h>
+#import "JPEngine.h"
 
 @implementation JPMethodSignature {
     NSString *_typeNames;
@@ -59,6 +60,17 @@
             arg = [_types substringWithRange:NSMakeRange(i - 1, 2)];
             [_argumentTypes removeLastObject];
             
+        } else if (c == '{') {
+            NSUInteger end = [[_types substringFromIndex:i] rangeOfString:@"}"].location + i;
+            arg = [_types substringWithRange:NSMakeRange(i, end - i + 1)];
+            if (i == 0) {
+                _returnType = arg;
+            } else {
+                [_argumentTypes addObject:arg];
+            }
+            i = (int)end;
+            continue;
+        
         } else {
             
             arg = [_types substringWithRange:NSMakeRange(i, 1)];
@@ -147,6 +159,12 @@
         return &ffi_type_float;
         case 'd':
         return &ffi_type_double;
+        case 'F':
+#if CGFLOAT_IS_DOUBLE
+        return &ffi_type_double;
+#else
+        return &ffi_type_float;
+#endif
         case 'B':
         return &ffi_type_uint8;
         case '^':
@@ -155,6 +173,27 @@
         return &ffi_type_pointer;
         case '#':
         return &ffi_type_pointer;
+        case '{':
+        {
+            NSString *typeStr = [NSString stringWithCString:c encoding:NSASCIIStringEncoding];
+            NSString *structName = [typeStr substringWithRange:NSMakeRange(1, typeStr.length - 2)];
+            ffi_type *type = malloc(sizeof(ffi_type));
+            type->alignment = 0;
+            type->size = 0;
+            type->type = FFI_TYPE_STRUCT;
+            NSDictionary *structDefine = [JPExtension registeredStruct][structName];
+            NSUInteger subTypeCount = [structDefine[@"keys"] count];
+            NSString *subTypes = structDefine[@"types"];
+            ffi_type **sub_types = malloc(sizeof(ffi_type *) * (subTypeCount + 1));
+            for (NSUInteger i=0; i<subTypeCount; i++) {
+                char subType = [subTypes characterAtIndex:i];
+                sub_types[i] = [self ffiTypeWithEncodingChar:&subType];
+                type->size += sub_types[i]->size;
+            }
+            sub_types[subTypeCount] = NULL;
+            type->elements = sub_types;
+            return type;
+        }
     }
     return NULL;
 }

--- a/Extensions/JPLibffi/JPMethodSignature.m
+++ b/Extensions/JPLibffi/JPMethodSignature.m
@@ -176,23 +176,25 @@
         case '{':
         {
             NSString *typeStr = [NSString stringWithCString:c encoding:NSASCIIStringEncoding];
-            NSString *structName = [typeStr substringWithRange:NSMakeRange(1, typeStr.length - 2)];
-            ffi_type *type = malloc(sizeof(ffi_type));
-            type->alignment = 0;
-            type->size = 0;
-            type->type = FFI_TYPE_STRUCT;
-            NSDictionary *structDefine = [JPExtension registeredStruct][structName];
-            NSUInteger subTypeCount = [structDefine[@"keys"] count];
-            NSString *subTypes = structDefine[@"types"];
-            ffi_type **sub_types = malloc(sizeof(ffi_type *) * (subTypeCount + 1));
-            for (NSUInteger i=0; i<subTypeCount; i++) {
-                char subType = [subTypes characterAtIndex:i];
-                sub_types[i] = [self ffiTypeWithEncodingChar:&subType];
-                type->size += sub_types[i]->size;
+            NSUInteger end = [typeStr rangeOfString:@"}"].location;
+            if (end != NSNotFound) {
+                NSString *structName = [typeStr substringWithRange:NSMakeRange(1, end - 1)];
+                ffi_type *type = malloc(sizeof(ffi_type));
+                type->alignment = 0;
+                type->size = 0;
+                type->type = FFI_TYPE_STRUCT;
+                NSDictionary *structDefine = [JPExtension registeredStruct][structName];
+                NSUInteger subTypeCount = [structDefine[@"keys"] count];
+                NSString *subTypes = structDefine[@"types"];
+                ffi_type **sub_types = malloc(sizeof(ffi_type *) * (subTypeCount + 1));
+                for (NSUInteger i=0; i<subTypeCount; i++) {
+                    sub_types[i] = [self ffiTypeWithEncodingChar:[subTypes cStringUsingEncoding:NSASCIIStringEncoding]];
+                    type->size += sub_types[i]->size;
+                }
+                sub_types[subTypeCount] = NULL;
+                type->elements = sub_types;
+                return type;
             }
-            sub_types[subTypeCount] = NULL;
-            type->elements = sub_types;
-            return type;
         }
     }
     return NULL;

--- a/JSPatch/JPEngine.h
+++ b/JSPatch/JPEngine.h
@@ -104,3 +104,4 @@
 - (void *)unboxPointer;
 - (Class)unboxClass;
 @end
+

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -13,6 +13,12 @@
 #import <UIKit/UIApplication.h>
 #endif
 
+#if CGFLOAT_IS_DOUBLE
+#define CGFloatValue doubleValue
+#else
+#define CGFloatValue floatValue
+#endif
+
 @implementation JPBoxing
 
 #define JPBOXING_GEN(_name, _prop, _type) \
@@ -1519,23 +1525,11 @@ static void getStructDataWithDict(void *structData, NSDictionary *dict, NSDictio
             JP_STRUCT_DATA_CASE('q', long long, longLongValue)
             JP_STRUCT_DATA_CASE('Q', unsigned long long, unsignedLongLongValue)
             JP_STRUCT_DATA_CASE('f', float, floatValue)
+            JP_STRUCT_DATA_CASE('F', CGFloat, CGFloatValue)
             JP_STRUCT_DATA_CASE('d', double, doubleValue)
             JP_STRUCT_DATA_CASE('B', BOOL, boolValue)
             JP_STRUCT_DATA_CASE('N', NSInteger, integerValue)
             JP_STRUCT_DATA_CASE('U', NSUInteger, unsignedIntegerValue)
-            
-            case 'F': {
-                int size = sizeof(CGFloat);
-                CGFloat val;
-                #if CGFLOAT_IS_DOUBLE
-                val = [dict[itemKeys[i]] doubleValue];
-                #else
-                val = [dict[itemKeys[i]] floatValue];
-                #endif
-                memcpy(structData + position, &val, size);
-                position += size;
-                break;
-            }
             
             case '*':
             case '^': {

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -1489,6 +1489,19 @@ static int sizeOfStructTypes(NSString *structTypes)
             JP_STRUCT_SIZE_CASE('B', BOOL)
             JP_STRUCT_SIZE_CASE('*', void *)
             JP_STRUCT_SIZE_CASE('^', void *)
+                
+            case '{': {
+                NSString *structTypeStr = [structTypes substringFromIndex:index];
+                NSUInteger end = [structTypeStr rangeOfString:@"}"].location;
+                if (end != NSNotFound) {
+                    NSString *subStructName = [structTypeStr substringWithRange:NSMakeRange(1, end - 1)];
+                    NSDictionary *subStructDefine = [JPExtension registeredStruct][subStructName];
+                    NSString *subStructTypes = subStructDefine[@"types"];
+                    size += sizeOfStructTypes(subStructTypes);
+                    index += (int)end;
+                    break;
+                }
+            }
             
             default:
                 break;
@@ -1503,12 +1516,12 @@ static void getStructDataWithDict(void *structData, NSDictionary *dict, NSDictio
     NSArray *itemKeys = structDefine[@"keys"];
     const char *structTypes = [structDefine[@"types"] cStringUsingEncoding:NSUTF8StringEncoding];
     int position = 0;
-    for (int i = 0; i < itemKeys.count; i ++) {
-        switch(structTypes[i]) {
+    for (NSString *itemKey in itemKeys) {
+        switch(*structTypes) {
             #define JP_STRUCT_DATA_CASE(_typeStr, _type, _transMethod) \
             case _typeStr: { \
                 int size = sizeof(_type);    \
-                _type val = [dict[itemKeys[i]] _transMethod];   \
+                _type val = [dict[itemKey] _transMethod];   \
                 memcpy(structData + position, &val, size);  \
                 position += size;    \
                 break;  \
@@ -1534,12 +1547,29 @@ static void getStructDataWithDict(void *structData, NSDictionary *dict, NSDictio
             case '*':
             case '^': {
                 int size = sizeof(void *);
-                void *val = [(JPBoxing *)dict[itemKeys[i]] unboxPointer];
+                void *val = [(JPBoxing *)dict[itemKey] unboxPointer];
                 memcpy(structData + position, &val, size);
                 break;
             }
+            case '{': {
+                NSString *subStructName = [NSString stringWithCString:structTypes encoding:NSASCIIStringEncoding];
+                NSUInteger end = [subStructName rangeOfString:@"}"].location;
+                if (end != NSNotFound) {
+                    subStructName = [subStructName substringWithRange:NSMakeRange(1, end - 1)];
+                    NSDictionary *subStructDefine = [JPExtension registeredStruct][subStructName];
+                    NSDictionary *subDict = dict[itemKey];
+                    int size = sizeOfStructTypes(subStructDefine[@"types"]);
+                    getStructDataWithDict(structData + position, subDict, subStructDefine);
+                    position += size;
+                    structTypes += end;
+                    break;
+                }
+            }
+            default:
+                break;
             
         }
+        structTypes ++;
     }
 }
 
@@ -1550,14 +1580,14 @@ static NSDictionary *getDictOfStruct(void *structData, NSDictionary *structDefin
     const char *structTypes = [structDefine[@"types"] cStringUsingEncoding:NSUTF8StringEncoding];
     int position = 0;
     
-    for (int i = 0; i < itemKeys.count; i ++) {
-        switch(structTypes[i]) {
+    for (NSString *itemKey in itemKeys) {
+        switch(*structTypes) {
             #define JP_STRUCT_DICT_CASE(_typeName, _type)   \
             case _typeName: { \
                 size_t size = sizeof(_type); \
                 _type *val = malloc(size);   \
                 memcpy(val, structData + position, size);   \
-                [dict setObject:@(*val) forKey:itemKeys[i]];    \
+                [dict setObject:@(*val) forKey:itemKey];    \
                 free(val);  \
                 position += size;   \
                 break;  \
@@ -1584,12 +1614,26 @@ static NSDictionary *getDictOfStruct(void *structData, NSDictionary *structDefin
                 size_t size = sizeof(void *);
                 void *val = malloc(size);
                 memcpy(val, structData + position, size);
-                [dict setObject:[JPBoxing boxPointer:val] forKey:itemKeys[i]];
+                [dict setObject:[JPBoxing boxPointer:val] forKey:itemKey];
                 position += size;
                 break;
             }
-            
+            case '{': {
+                NSString *subStructName = [NSString stringWithCString:structTypes encoding:NSASCIIStringEncoding];
+                NSUInteger end = [subStructName rangeOfString:@"}"].location;
+                if (end != NSNotFound) {
+                    subStructName = [subStructName substringWithRange:NSMakeRange(1, end - 1)];
+                    NSDictionary *subStructDefine = [JPExtension registeredStruct][subStructName];
+                    int size = sizeOfStructTypes(subStructDefine[@"types"]);
+                    NSDictionary *subDict = getDictOfStruct(structData + position, subStructDefine);
+                    [dict setObject:subDict forKey:itemKey];
+                    position += size;
+                    structTypes += end;
+                    break;
+                }
+            }
         }
+        structTypes ++;
     }
     return dict;
 }


### PR DESCRIPTION
* How to use struct in c function.
```js
// example for CGRect
require('JPEngine').defineStruct({
    "name": "CGSize",
    "types": "FF",
    "keys": ["width", "height"]
});
require('JPEngine').defineStruct({
    "name": "CGPoint",
    "types": "FF",
    "keys": ["x", "y"]
});
require('JPEngine').defineStruct({
    "name": "CGRect",
    "types": "{CGPoint}{CGSize}",
    "keys": ["origin", "size"]
});

defineCFunction("cfuncWithCGRect", "{CGRect}, {CGRect}")
var ret = cfuncWithCGRect({origin:{x:1,y:2},size:{width:3, height:4}});
console.log("testCfuncWithCGRect", JSON.stringify(ret), ret.origin, ret.origin.x);
 return ret.origin.x == 1 && ret.origin.y == 2 && ret.size.width == 3 && ret.size.height == 4;
```

* Why we can use a struct in c function with ffi.

We could define a struct type in ffi just like this:
```yaml
# example for CGRect
alignment: 0
size: 32
type: FFI_TYPE_STRUCT
elements:
    - 0:
        alignment: 0
        size: 16
        type: FFI_TYPE_STRUCT
        elements:
            - &ffi_type_double
            - &ffi_type_double
    - 1:
        alignment: 0
        size: 16
        type: FFI_TYPE_STRUCT
        elements:
            - &ffi_type_double
            - &ffi_type_double
```

* What else in this pull request.

    - Extract 2 methods for value converting from method `callCFunction:arguments:` to make the code more readable.
    - Use macro `CGFloatValue` and `numberWithCGFloat` to simplify the code in function `getStructDataWithDict`.

* What else we could do next.

    We could make `block` support struct also with the same solution.
