### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Go to wiki page for more details: [Base Usage](https://github.com/bang590/JSPatc
 
 
 
-####defineClass
+#### defineClass
 You can redefine an existing class and override methods.
 
 ```objc
@@ -212,7 +212,7 @@ defineClass("JPTableViewController", {
 
 Go to wiki page for more details: [Usage of defineClass](https://github.com/bang590/JSPatch/wiki/Usage-of-defineClass)
 
-####Extensions
+#### Extensions
 
 There are some extensions provide support for custom struct type, C methods and other functional, call `+addExtensions:` after starting engine to add extensions:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
