### PR TITLE
Manage Block memory with ARC

### DIFF
--- a/Demo/iOSDemo/JSPatchTests/JPTestObject.m
+++ b/Demo/iOSDemo/JSPatchTests/JPTestObject.m
@@ -198,6 +198,14 @@ typedef id (^JPTestObjectBlock)(NSDictionary *dict, UIView *view);
     self.callBlockWithStringAndIntReturnValuePassed = [ret isEqualToString:@"succ"];
 }
 
+- (void)callBlockDelay:(id(^)(NSString *str, int num))block
+{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        id ret = block(@"stringFromOC", 42);
+        self.callBlockWithStringAndIntReturnValuePassed = [ret isEqualToString:@"succ"];
+    });
+}
+
 - (void)callBlockWithArrayAndView:(void(^)(NSArray *arr, UIView *view))block
 {
     UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];

--- a/Demo/iOSDemo/JSPatchTests/test.js
+++ b/Demo/iOSDemo/JSPatchTests/test.js
@@ -276,6 +276,19 @@ require('JPEngine').defineStruct({
     obj.setCallBlockWithStringAndIntPassed(str.toJS() == "stringFromOC" && num == 42)
     return "succ"
   }))
+ 
+  obj.callBlockDelay(block("id, NSString *, int", function(str, num) {
+    obj.setCallBlockWithStringAndIntPassed(str.toJS() == "stringFromOC" && num == 42)
+    return "succ"
+  }))
+ 
+ // try to test block memory bad access.
+ // request big memory to trigger JSContext gc, then the above argument function(str, num) will be free.
+  require('JPEngine').addExtensions(['JPCFunction'])
+  for (var i = 0; i < 100000; i ++) {
+      defineCFunction("malloc", "void *, size_t")
+      var p = malloc(10)
+  }
 
   obj.callBlockWithArrayAndView(block("id, NSArray *, UIView *", function(arr, view) {
     var viewFrame = view.frame()

--- a/Demo/iOSDemo/JSPatchTests/test.js
+++ b/Demo/iOSDemo/JSPatchTests/test.js
@@ -282,8 +282,8 @@ require('JPEngine').defineStruct({
     return "succ"
   }))
  
- // try to test block memory bad access.
- // request big memory to trigger JSContext gc, then the above argument function(str, num) will be free.
+ // request big memory to trigger JSContext gc
+ // make sure the above argument function(str, num) not freed before calling.
   require('JPEngine').addExtensions(['JPCFunction'])
   for (var i = 0; i < 100000; i ++) {
       defineCFunction("malloc", "void *, size_t")

--- a/Extensions/JPBlock/JPBlock.m
+++ b/Extensions/JPBlock/JPBlock.m
@@ -21,8 +21,6 @@
 
 + (id)blockWithBlockObj:(JPBlockWrapper *)blockObj
 {
-    void *blockPtr = [blockObj blockPtr];
-    id blk = [((__bridge id)blockPtr) copy];
-    return blk;
+    return [blockObj blockPtr];
 }
 @end

--- a/Extensions/JPBlock/JPBlockWrapper.m
+++ b/Extensions/JPBlock/JPBlockWrapper.m
@@ -29,6 +29,7 @@ struct JPSimulateBlock {
     int reserved;
     void *invoke;
     struct JPSimulateBlockDescriptor *descriptor;
+    void *wrapper;
 };
 
 struct JPSimulateBlockDescriptor {
@@ -37,25 +38,31 @@ struct JPSimulateBlockDescriptor {
         unsigned long int reserved;
         unsigned long int size;
     };
-    
-    /*
+
     //Block_descriptor_2
-    //no need
     struct {
         // requires BLOCK_HAS_COPY_DISPOSE
         void (*copy)(void *dst, const void *src);
         void (*dispose)(const void *);
     };
-    */
-    
+
     //Block_descriptor_3
     struct {
         // requires BLOCK_HAS_SIGNATURE
         const char *signature;
-        const char *layout;
     };
 };
 
+void copy_helper(struct JPSimulateBlock *dst, struct JPSimulateBlock *src)
+{
+    // do not copy anything is this funcion! just retain if need.
+    CFRetain(dst->wrapper);
+}
+
+void dispose_helper(struct JPSimulateBlock *src)
+{
+    CFRelease(src->wrapper);
+}
 
 
 @interface JPBlockWrapper ()
@@ -76,7 +83,7 @@ struct JPSimulateBlockDescriptor {
 void JPBlockInterpreter(ffi_cif *cif, void *ret, void **args, void *userdata)
 {
     JPBlockWrapper *blockObj = (__bridge JPBlockWrapper*)userdata;
-    
+
     NSMutableArray *params = [[NSMutableArray alloc] init];
     for (int i = 1; i < blockObj.signature.argumentTypes.count; i ++) {
         id param;
@@ -113,8 +120,7 @@ void JPBlockInterpreter(ffi_cif *cif, void *ret, void **args, void *userdata)
     }
     
     JSValue *jsResult = [blockObj.jsFunction callWithArguments:params];
-    NSLog(@"memleak JPBlockWrapper used %p, %p", blockObj, jsResult);
-    
+
     switch ([blockObj.signature.returnType UTF8String][0]) {
             
     #define JP_BLOCK_RET_CASE(_typeString, _type, _selector) \
@@ -165,7 +171,6 @@ void JPBlockInterpreter(ffi_cif *cif, void *ret, void **args, void *userdata)
         _generatedPtr = NO;
         self.jsFunction = jsFunction;
         self.signature = [[JPMethodSignature alloc] initWithBlockTypeNames:typeString];
-        NSLog(@"memleak JPBlockWrapper init %p", self);
     }
     return self;
 }
@@ -200,37 +205,36 @@ void JPBlockInterpreter(ffi_cif *cif, void *ret, void **args, void *userdata)
             NSAssert(NO, @"generate block error");
         }
     }
-    
+
     struct JPSimulateBlockDescriptor descriptor = {
         0,
         sizeof(struct JPSimulateBlock),
-        [self.signature.types cStringUsingEncoding:NSUTF8StringEncoding],
-        NULL
+        (void (*)(void *dst, const void *src))copy_helper,
+        (void (*)(const void *src))dispose_helper,
+        [self.signature.types cStringUsingEncoding:NSASCIIStringEncoding]
     };
     
     _descriptor = malloc(sizeof(struct JPSimulateBlockDescriptor));
     memcpy(_descriptor, &descriptor, sizeof(struct JPSimulateBlockDescriptor));
-    
+
     struct JPSimulateBlock simulateBlock = {
         &_NSConcreteStackBlock,
-        (BLOCK_HAS_SIGNATURE), 0,
+        (BLOCK_HAS_COPY_DISPOSE | BLOCK_HAS_SIGNATURE),
+        0,
         blockImp,
-        _descriptor
+        _descriptor,
+        (__bridge void*)self
     };
-    
-    _blockPtr = malloc(sizeof(struct JPSimulateBlock));
-    memcpy(_blockPtr, &simulateBlock, sizeof(struct JPSimulateBlock));
-    
+
+    _blockPtr = Block_copy(&simulateBlock);
     return _blockPtr;
 }
 
 - (void)dealloc
 {
-    NSLog(@"memleak JPBlockWrapper dealloc %p, %p", self, _jsFunction);
     ffi_closure_free(_closure);
     free(_args);
     free(_cifPtr);
-    free(_blockPtr);
     free(_descriptor);
     return;
 }

--- a/Extensions/JPBlock/JPBlockWrapper.m
+++ b/Extensions/JPBlock/JPBlockWrapper.m
@@ -113,6 +113,7 @@ void JPBlockInterpreter(ffi_cif *cif, void *ret, void **args, void *userdata)
     }
     
     JSValue *jsResult = [blockObj.jsFunction callWithArguments:params];
+    NSLog(@"memleak JPBlockWrapper used %p, %p", blockObj, jsResult);
     
     switch ([blockObj.signature.returnType UTF8String][0]) {
             
@@ -164,6 +165,7 @@ void JPBlockInterpreter(ffi_cif *cif, void *ret, void **args, void *userdata)
         _generatedPtr = NO;
         self.jsFunction = jsFunction;
         self.signature = [[JPMethodSignature alloc] initWithBlockTypeNames:typeString];
+        NSLog(@"memleak JPBlockWrapper init %p", self);
     }
     return self;
 }
@@ -224,6 +226,7 @@ void JPBlockInterpreter(ffi_cif *cif, void *ret, void **args, void *userdata)
 
 - (void)dealloc
 {
+    NSLog(@"memleak JPBlockWrapper dealloc %p, %p", self, _jsFunction);
     ffi_closure_free(_closure);
     free(_args);
     free(_cifPtr);

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -1217,6 +1217,7 @@ static id callSelector(NSString *className, NSString *selectorName, JSValue *arg
                     if (JPBlockClass && ![blkJSVal[@"blockObj"] isUndefined]) {
                         __autoreleasing id cb = [JPBlockClass performSelector:@selector(blockWithBlockObj:) withObject:[blkJSVal[@"blockObj"] toObject]];
                         [invocation setArgument:&cb atIndex:i];
+                        Block_release((__bridge void *)cb);
                     } else {
                         __autoreleasing id cb = genCallbackBlock(arguments[i-2]);
                         [invocation setArgument:&cb atIndex:i];


### PR DESCRIPTION
fix issue #789 .
Refactor Block memory management based on LLVM's documentation about Block Implementation:
https://clang.llvm.org/docs/Block-ABI-Apple.html