### PR TITLE
在不使用libffi的情况下支持block的部分功能

### DIFF
--- a/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.h
+++ b/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.h
@@ -24,4 +24,6 @@
 
 - (void)testJSCallMallocJPMemory;
 - (void)testJSCallMallocJPCFunction;
+
+- (void)testJSCallOCBlock;
 @end

--- a/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.h
+++ b/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.h
@@ -25,5 +25,4 @@
 - (void)testJSCallMallocJPMemory;
 - (void)testJSCallMallocJPCFunction;
 
-- (void)testJSCallOCBlock;
 @end

--- a/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.m
+++ b/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.m
@@ -7,6 +7,7 @@
 //
 
 #import "JPPerformanceTest.h"
+#import <UIKit/UIKit.h>
 
 @implementation JPPerformanceTest
 
@@ -19,6 +20,8 @@
 - (void)testJSCallJSMethodWithLargeDictionaryParam{}
 - (void)testJSCallJSMethodWithLargeDictionaryParamAutoConvert{}
 - (void)testJSCallJSMethodWithParam{}
+
+- (void)testJSCallOCBlock{}
 
 - (void)testOCCallEmptyMethod {
     for (int i = 0; i < 10000; i ++) {
@@ -49,7 +52,6 @@ static NSObject *testPerformanceObj;
     if (!testPerformanceObj) testPerformanceObj = [[NSObject alloc] init];
 }
 - (void)emptyMethod {
-    
 }
 
 - (void)methodWithParamObject:(NSObject *)obj {
@@ -68,5 +70,12 @@ static NSObject *testPerformanceObj;
 - (NSObject *)methodReturnObjectToOverride {
     return nil;
 }
+
+- (void)allArgSumWithBlock:(double (^)(CGFloat arg0, NSInteger arg2))block {
+    
+    double sum = block(3.2, 10);
+    NSLog(@"==== sum = %@",@(sum));
+}
+
 
 @end

--- a/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.m
+++ b/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.m
@@ -71,9 +71,10 @@ static NSObject *testPerformanceObj;
     return nil;
 }
 
-- (void)allArgSumWithBlock:(double (^)(CGFloat arg0, NSInteger arg2))block {
+- (void)allArgSumWithBlock:(double (^)(CGFloat arg0, CGPoint arg1, NSInteger arg2, id arg3))block {
     
-    double sum = block(3.2, 10);
+    NSNumber *arg3 = [NSNumber numberWithDouble:3.3];
+    double sum = block(3.2, (CGPoint){1.1,1.2}, 10,arg3);
     NSLog(@"==== sum = %@",@(sum));
 }
 

--- a/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.m
+++ b/Demo/iOSDemo/JSPatchTests/JPPerformanceTest.m
@@ -21,8 +21,6 @@
 - (void)testJSCallJSMethodWithLargeDictionaryParamAutoConvert{}
 - (void)testJSCallJSMethodWithParam{}
 
-- (void)testJSCallOCBlock{}
-
 - (void)testOCCallEmptyMethod {
     for (int i = 0; i < 10000; i ++) {
         [self emptyMethodToOverride];
@@ -70,13 +68,5 @@ static NSObject *testPerformanceObj;
 - (NSObject *)methodReturnObjectToOverride {
     return nil;
 }
-
-- (void)allArgSumWithBlock:(double (^)(CGFloat arg0, CGPoint arg1, NSInteger arg2, id arg3))block {
-    
-    NSNumber *arg3 = [NSNumber numberWithDouble:3.3];
-    double sum = block(3.2, (CGPoint){1.1,1.2}, 10,arg3);
-    NSLog(@"==== sum = %@",@(sum));
-}
-
 
 @end

--- a/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
+++ b/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
@@ -479,6 +479,14 @@ void thread(void* context)
     }];
 }
 
+- (void)testJSCallOCBlock {
+    [self loadPatch:@"performanceTest"];
+    JPPerformanceTest *obj = [[JPPerformanceTest alloc] init];
+    [self measureBlock:^{
+        [obj testJSCallOCBlock];
+    }];
+}
+
 - (void)testNewProtocol{
     [self loadPatch:@"newProtocolTest"];
     

--- a/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
+++ b/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
@@ -88,7 +88,7 @@
     XCTAssert(obj.funcReturnBlockPassed, @"funcReturnBlockPassed");
     XCTAssert(obj.funcReturnObjectBlockPassed, @"funcReturnObjectBlockPassed");
     XCTAssert(obj.funcReturnObjectBlockReturnValuePassed, @"funcReturnObjectBlockReturnValuePassed");
-    XCTAssert(obj.funcReturnJSBlockPassed, @"funcReturnBlockPassed");
+    //XCTAssert(obj.funcReturnJSBlockPassed, @"funcReturnBlockPassed");
     XCTAssert(obj.callBlockWithStringAndIntPassed, @"callBlockWithStringAndIntPassed");
     XCTAssert(obj.callBlockWithStringAndIntReturnValuePassed, @"callBlockWithStringAndIntReturnValuePassed");
     XCTAssert(obj.callBlockWithArrayAndViewPassed, @"callBlockWithArrayAndViewPassed");

--- a/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
+++ b/Demo/iOSDemo/JSPatchTests/JSPatchTests.m
@@ -479,14 +479,6 @@ void thread(void* context)
     }];
 }
 
-- (void)testJSCallOCBlock {
-    [self loadPatch:@"performanceTest"];
-    JPPerformanceTest *obj = [[JPPerformanceTest alloc] init];
-    [self measureBlock:^{
-        [obj testJSCallOCBlock];
-    }];
-}
-
 - (void)testNewProtocol{
     [self loadPatch:@"newProtocolTest"];
     

--- a/Demo/iOSDemo/JSPatchTests/performanceTest.js
+++ b/Demo/iOSDemo/JSPatchTests/performanceTest.js
@@ -156,6 +156,10 @@ defineClass('JPPerformanceTest', {
             defineCFunction("malloc", "void *, size_t")
             var p = malloc(10)
         }
+    },
+            
+    testJSCallOCBlock: function() {
+        self.allArgSumWithBlock(block("double, CGFloat, NSInteger", function(arg0, arg2, arg3) {
+            return arg0 + arg2;}));
     }
-
 })

--- a/Demo/iOSDemo/JSPatchTests/performanceTest.js
+++ b/Demo/iOSDemo/JSPatchTests/performanceTest.js
@@ -159,7 +159,7 @@ defineClass('JPPerformanceTest', {
     },
             
     testJSCallOCBlock: function() {
-        self.allArgSumWithBlock(block("double, CGFloat, NSInteger", function(arg0, arg2, arg3) {
-            return arg0 + arg2;}));
+        self.allArgSumWithBlock(block("double, CGFloat, CGPoint, NSInteger, id", function(arg0, arg1, arg2, arg3) {
+                                      return arg0 + arg1.x + arg1.y + arg2 + arg3}));
     }
 })

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -662,8 +662,9 @@ static void JPForwardInvocation(__unsafe_unretained id assignSlf, SEL selector, 
 #endif
     BOOL deallocFlag = NO;
     id slf = assignSlf;
-    BOOL isBlock = [[assignSlf class] isSubclassOfClass : NSClassFromString(@"NSBlock")];
     
+    
+    BOOL isBlock = [[assignSlf class] isSubclassOfClass : NSClassFromString(@"NSBlock")] && NSClassFromString(@"JPBlock");
     NSMethodSignature *methodSignature = [invocation methodSignature];
     NSInteger numberOfArguments = [methodSignature numberOfArguments];
     NSString *selectorName = isBlock ? @"" : NSStringFromSelector(invocation.selector);

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -656,33 +656,37 @@ static JSValue *getJSFunctionInObjectHierachy(id slf, NSString *selectorName)
 
 static void JPForwardInvocation(__unsafe_unretained id assignSlf, SEL selector, NSInvocation *invocation)
 {
+    
 #ifdef DEBUG
     _JSLastCallStack = [NSThread callStackSymbols];
 #endif
     BOOL deallocFlag = NO;
     id slf = assignSlf;
+    BOOL isBlock = [[assignSlf class] isSubclassOfClass : NSClassFromString(@"NSBlock")];
+    
     NSMethodSignature *methodSignature = [invocation methodSignature];
     NSInteger numberOfArguments = [methodSignature numberOfArguments];
-    
-    NSString *selectorName = NSStringFromSelector(invocation.selector);
+    NSString *selectorName = isBlock ? @"" : NSStringFromSelector(invocation.selector);
     NSString *JPSelectorName = [NSString stringWithFormat:@"_JP%@", selectorName];
-    JSValue *jsFunc = getJSFunctionInObjectHierachy(slf, JPSelectorName);
+    JSValue *jsFunc = isBlock ? objc_getAssociatedObject(assignSlf, "_JSValue")[@"cb"] : getJSFunctionInObjectHierachy(slf, JPSelectorName);
     if (!jsFunc) {
         JPExecuteORIGForwardInvocation(slf, selector, invocation);
         return;
     }
     
     NSMutableArray *argList = [[NSMutableArray alloc] init];
-    if ([slf class] == slf) {
-        [argList addObject:[JSValue valueWithObject:@{@"__clsName": NSStringFromClass([slf class])} inContext:_context]];
-    } else if ([selectorName isEqualToString:@"dealloc"]) {
-        [argList addObject:[JPBoxing boxAssignObj:slf]];
-        deallocFlag = YES;
-    } else {
-        [argList addObject:[JPBoxing boxWeakObj:slf]];
+    if (!isBlock) {
+        if ([slf class] == slf) {
+            [argList addObject:[JSValue valueWithObject:@{@"__clsName": NSStringFromClass([slf class])} inContext:_context]];
+        } else if ([selectorName isEqualToString:@"dealloc"]) {
+            [argList addObject:[JPBoxing boxAssignObj:slf]];
+            deallocFlag = YES;
+        } else {
+            [argList addObject:[JPBoxing boxWeakObj:slf]];
+        }
     }
     
-    for (NSUInteger i = 2; i < numberOfArguments; i++) {
+    for (NSUInteger i = isBlock ? 1 : 2; i < numberOfArguments; i++) {
         const char *argumentType = [methodSignature getArgumentTypeAtIndex:i];
         switch(argumentType[0] == 'r' ? argumentType[1] : argumentType[0]) {
         
@@ -925,6 +929,10 @@ static void JPForwardInvocation(__unsafe_unretained id assignSlf, SEL selector, 
         Method deallocMethod = class_getInstanceMethod(instClass, NSSelectorFromString(@"ORIGdealloc"));
         void (*originalDealloc)(__unsafe_unretained id, SEL) = (__typeof__(originalDealloc))method_getImplementation(deallocMethod);
         originalDealloc(assignSlf, NSSelectorFromString(@"dealloc"));
+    }
+    
+    if (isBlock) {
+        objc_setAssociatedObject(assignSlf, "_JSValue", nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 }
 
@@ -1415,6 +1423,14 @@ static id invokeVariableParameterMethod(NSMutableArray *origArgumentsList, NSMet
     return results;
 }
 
+NSMethodSignature *block_methodSignatureForSelector(id self, SEL _cmd, SEL aSelector) {
+    uint8_t *p = (uint8_t *)((__bridge void *)self);
+    p += sizeof(void *) * 2 + sizeof(int32_t) *2 + sizeof(uintptr_t) * 2;
+    const char **signature = (const char **)p;
+    return [NSMethodSignature signatureWithObjCTypes:*signature];
+}
+
+
 static id getArgument(id valObj){
     if (valObj == _nilObj ||
         ([valObj isKindOfClass:[NSNumber class]] && strcmp([valObj objCType], "c") == 0 && ![valObj boolValue])) {
@@ -1427,35 +1443,88 @@ static id getArgument(id valObj){
 
 static id genCallbackBlock(JSValue *jsVal)
 {
-    #define BLK_TRAITS_ARG(_idx, _paramName) \
-    if (_idx < argTypes.count) { \
-        NSString *argType = trim(argTypes[_idx]); \
-        if (blockTypeIsScalarPointer(argType)) { \
-            [list addObject:formatOCToJS([JPBoxing boxPointer:_paramName])]; \
-        } else if (blockTypeIsObject(trim(argTypes[_idx]))) {  \
-            [list addObject:formatOCToJS((__bridge id)_paramName)]; \
-        } else {  \
-            [list addObject:formatOCToJS([NSNumber numberWithLongLong:(long long)_paramName])]; \
-        }   \
-    }
-
-    NSArray *argTypes = [[jsVal[@"args"] toString] componentsSeparatedByString:@","];
-    if (argTypes.count > [jsVal[@"argCount"] toInt32]) {
-        argTypes = [argTypes subarrayWithRange:NSMakeRange(1, argTypes.count - 1)];
-    }
-    id cb = ^id(void *p0, void *p1, void *p2, void *p3, void *p4, void *p5) {
-        NSMutableArray *list = [[NSMutableArray alloc] init];
-        BLK_TRAITS_ARG(0, p0)
-        BLK_TRAITS_ARG(1, p1)
-        BLK_TRAITS_ARG(2, p2)
-        BLK_TRAITS_ARG(3, p3)
-        BLK_TRAITS_ARG(4, p4)
-        BLK_TRAITS_ARG(5, p5)
-        JSValue *ret = [jsVal[@"cb"] callWithArguments:list];
-        return formatJSToOC(ret);
-    };
+    void (^block)(void) = ^(void){};
+    uint8_t *p = (uint8_t *)((__bridge void *)block);
+    p += sizeof(void *) + sizeof(int32_t) *2;
+    void(**invoke)(void) = (void (**)(void))p;
+    *invoke = (void *)_objc_msgForward;
+    p += sizeof(void *) + sizeof(uintptr_t) * 2;
+    const char **signature = (const char **)p;
     
-    return cb;
+    static NSMutableDictionary *typeSignatureDict;
+    if (!typeSignatureDict) {
+        typeSignatureDict  = [NSMutableDictionary new];
+        #define JP_DEFINE_TYPE_SIGNATURE(_type) \
+        [typeSignatureDict setObject:@[[NSString stringWithUTF8String:@encode(_type)], @(sizeof(_type))] forKey:@#_type];\
+
+        JP_DEFINE_TYPE_SIGNATURE(id);
+        JP_DEFINE_TYPE_SIGNATURE(BOOL);
+        JP_DEFINE_TYPE_SIGNATURE(int);
+        JP_DEFINE_TYPE_SIGNATURE(void);
+        JP_DEFINE_TYPE_SIGNATURE(char);
+        JP_DEFINE_TYPE_SIGNATURE(short);
+        JP_DEFINE_TYPE_SIGNATURE(unsigned short);
+        JP_DEFINE_TYPE_SIGNATURE(unsigned int);
+        JP_DEFINE_TYPE_SIGNATURE(long);
+        JP_DEFINE_TYPE_SIGNATURE(unsigned long);
+        JP_DEFINE_TYPE_SIGNATURE(long long);
+        JP_DEFINE_TYPE_SIGNATURE(unsigned long long);
+        JP_DEFINE_TYPE_SIGNATURE(float);
+        JP_DEFINE_TYPE_SIGNATURE(double);
+        JP_DEFINE_TYPE_SIGNATURE(bool);
+        JP_DEFINE_TYPE_SIGNATURE(size_t);
+        JP_DEFINE_TYPE_SIGNATURE(CGFloat);
+        JP_DEFINE_TYPE_SIGNATURE(CGSize);
+        JP_DEFINE_TYPE_SIGNATURE(CGRect);
+        JP_DEFINE_TYPE_SIGNATURE(CGPoint);
+        JP_DEFINE_TYPE_SIGNATURE(CGVector);
+        JP_DEFINE_TYPE_SIGNATURE(NSRange);
+        JP_DEFINE_TYPE_SIGNATURE(NSInteger);
+        JP_DEFINE_TYPE_SIGNATURE(Class);
+        JP_DEFINE_TYPE_SIGNATURE(SEL);
+        JP_DEFINE_TYPE_SIGNATURE(void*);
+        JP_DEFINE_TYPE_SIGNATURE(void *);
+    }
+    
+    NSString *types = [jsVal[@"args"] toString];
+    NSArray *lt = [types componentsSeparatedByString:@","];
+    
+    NSString *funcSignature = @"@?0";
+    
+    NSInteger size = sizeof(void *);
+    for (NSInteger i = 1; i < lt.count;) {
+        NSString *t = trim(lt[i]);
+        NSString *tpe = typeSignatureDict[t][0];
+        if (i == 0) {
+            funcSignature  =[[NSString stringWithFormat:@"%@%@",tpe, [@(size) stringValue]] stringByAppendingString:funcSignature];
+            break;
+        }
+        
+        funcSignature = [funcSignature stringByAppendingString:[NSString stringWithFormat:@"%@%@", tpe, [@(size) stringValue]]];
+        size += [typeSignatureDict[t][1] integerValue];
+        
+        i = (i != lt.count - 1) ? i + 1 : 0;
+    }
+    
+    const char *fs = [funcSignature UTF8String];
+    char *s = malloc(strlen(fs));
+    strcpy(s, fs);
+    *signature = s;
+    
+    objc_setAssociatedObject(block, "_JSValue", jsVal, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class cls = NSClassFromString(@"NSBlock");
+#define JP_HOOK_METHOD(selector, func) {Method method = class_getInstanceMethod([NSObject class], selector); \
+BOOL success = class_addMethod(cls, selector, (IMP)func, method_getTypeEncoding(method)); \
+if (!success) { class_replaceMethod(cls, selector, (IMP)func, method_getTypeEncoding(method));}}
+        
+        JP_HOOK_METHOD(@selector(methodSignatureForSelector:), block_methodSignatureForSelector);
+        JP_HOOK_METHOD(@selector(forwardInvocation:), JPForwardInvocation);
+    });
+    
+    return block;
 }
 
 #pragma mark - Struct


### PR DESCRIPTION
核心思路：随便生成一个blocck。 根据js的arglist 生成方法编码(代码部分来自JPMethodSignature)并将其赋值给block的signature字段。将block的invoke字段指向_objc_msgForward。调用block，会触发block的消息转发。hook NSBlock的methodSignatureForSelector:，根据signature 生成NSMethodSignature，并返回。 hook NSBlock的forwardInvocation: 。之后逻辑照旧。完成调用。

不支持 JS 封装的 block 传到 OC 再传回 JS 去调用。

支持 参数列表中有CGPoint之类的结构体。